### PR TITLE
Notice to install all dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Package to build the mlr3 [bookdown](https://bookdown.org/) book.
 
-To install all necessary dependencies for the book, install the [https://github.com/mlr-org/mlr3book](mlr3book) package using [https://cran.r-project.org/package=remotes](remotes):
+To install all necessary dependencies for the book, install the [mlr3book](https://github.com/mlr-org/mlr3book) package using [remotes](https://cran.r-project.org/package=remotes):
 ```{r index-1, eval=FALSE}
 remotes::install_github("mlr-org/mlr3book", dependencies = TRUE)
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 Package to build the mlr3 [bookdown](https://bookdown.org/) book.
 
+To install all necessary dependencies for the book, install the `r gh_pkg("mlr-org/mlr3book")` package using `r cran_pkg("remotes")`:
+```{r index-1, eval=FALSE}
+remotes::install_github("mlr-org/mlr3book", dependencies = TRUE)
+```
+
 To build the book, run the following command in the repository root:
 ```{r}
 pkgload::load_all()

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Package to build the mlr3 [bookdown](https://bookdown.org/) book.
 
-To install all necessary dependencies for the book, install the [mlr3book](https://github.com/mlr-org/mlr3book) package using [remotes](https://cran.r-project.org/package=remotes):
+To install all necessary dependencies for the book, install the this package using [remotes](https://cran.r-project.org/package=remotes):
 ```{r index-1, eval=FALSE}
 remotes::install_github("mlr-org/mlr3book", dependencies = TRUE)
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Package to build the mlr3 [bookdown](https://bookdown.org/) book.
 
-To install all necessary dependencies for the book, install the `r gh_pkg("mlr-org/mlr3book")` package using `r cran_pkg("remotes")`:
+To install all necessary dependencies for the book, install the [https://github.com/mlr-org/mlr3book](mlr3book) package using [https://cran.r-project.org/package=remotes](remotes):
 ```{r index-1, eval=FALSE}
 remotes::install_github("mlr-org/mlr3book", dependencies = TRUE)
 ```


### PR DESCRIPTION
Adds a notice in the README that you should probably install all dependencies of the book.
This notice was previously only found on the first page of the book.