### PR TITLE
Fail the build if book rendering fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ dist: xenial
 sudo: false
 cache: packages
 latex: true
+remotes: mlr-org/mlr3book
 
-after_success:
-  - R CMD INSTALL "${PKG_TARBALL}"
+script:
   - Rscript -e 'mlr3book::render_mlr3book()'
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: xenial
 sudo: false
 cache: packages
 latex: true
-remotes: mlr-org/mlr3book
+r_github_packages: mlr-org/mlr3book
 
 script:
   - Rscript -e 'mlr3book::render_mlr3book()'

--- a/bookdown/03-pipelines.Rmd
+++ b/bookdown/03-pipelines.Rmd
@@ -276,7 +276,6 @@ It is important to "unbranch" again after "branching", so that the outputs are m
 In the following we first create the branched graph and then show what happens if the "unbranching" is not applied.
 
 ```{r 03-pipelines-024}
-i
 graph = mlr_pipeops$get("branch", c("null", "pca", "scale")) %>>%
   gunion(list(
       mlr_pipeops$get("null", id = "null1"),

--- a/bookdown/03-pipelines.Rmd
+++ b/bookdown/03-pipelines.Rmd
@@ -276,6 +276,7 @@ It is important to "unbranch" again after "branching", so that the outputs are m
 In the following we first create the branched graph and then show what happens if the "unbranching" is not applied.
 
 ```{r 03-pipelines-024}
+i
 graph = mlr_pipeops$get("branch", c("null", "pca", "scale")) %>>%
   gunion(list(
       mlr_pipeops$get("null", id = "null1"),


### PR DESCRIPTION
Previously the rendering was done in `after_success`. However, failing tasks in this stage do not fail the build.

Now we render in the `script` stage and install `mlr3book` from GH instead of building it locally and checking the package. This save some seconds.