### PR TITLE
Enable cache

### DIFF
--- a/bookdown/index.Rmd
+++ b/bookdown/index.Rmd
@@ -39,7 +39,7 @@ if(!knitr:::is_html_output())
 htmltools::tagList(rmarkdown::html_dependency_font_awesome())
 
 old.hooks = fansi::set_knit_hooks(knitr::knit_hooks)
-knitr::opts_chunk$set(collapse = TRUE, cache = FALSE)
+knitr::opts_chunk$set(collapse = TRUE, cache = TRUE, cache.lazy = FALSE)
 lgr::get_logger("mlr3")$set_threshold("warn")
 requireNamespace("kableExtra")
 library("R6")


### PR DESCRIPTION
Should be safe to use with `cache.lazy == FALSE`.
We might want to document how to clear the cache though.