### PR TITLE
correct figure scaling for pdf and html

### DIFF
--- a/bookdown/02-basics.Rmd
+++ b/bookdown/02-basics.Rmd
@@ -845,7 +845,7 @@ We can now normalize in rows and columns of the confusion matrix to derive sever
 * **Positive Predictive Value PPV**: If we predict positive how likely is it a true positive?
 * **Negative Predictive Value NPV**: If we predict negative how likely is it a true negative?
 
-```{r 02-basics-059, echo = FALSE}
+```{r 02-basics-059, echo = FALSE, out.width="98%"}
 knitr::include_graphics("images/confusion_matrix(wikipedia).png")
 ```
 


### PR DESCRIPTION
The simple addition of `out.width="x%"` allows use of 'oversized' graphics which will get shrunk correctly in both html and pdf mode.

