### PR TITLE
three more correct figure scaling for pdf and html

### DIFF
--- a/bookdown/03-optimization.Rmd
+++ b/bookdown/03-optimization.Rmd
@@ -350,7 +350,7 @@ Work in progress :) - via package _mlr3fswrap_
 In order to obtain unbiased performance estimates for learners, all parts of the model building (preprocessing and model selection steps) should be included in the resampling, i.e., repeated for every pair of training/test data.
 For steps that themselves require resampling like hyperparameter tuning or feature-selection (via the wrapper approach) this results in two nested resampling loops.
 
-```{r 03-optimization-017, echo = FALSE}
+```{r 03-optimization-017, echo = FALSE, out.width="98%"}
 knitr::include_graphics("images/nested_resampling.png")
 ```
 
@@ -443,4 +443,3 @@ Or take a look at the confusion matrix of the joined predictions:
 ```{r 03-optimization-022}
 rr$prediction()$confusion
 ```
-

--- a/bookdown/04-pipelines.Rmd
+++ b/bookdown/04-pipelines.Rmd
@@ -9,7 +9,7 @@ We will most often use the term "Graph" in this manual but it can interchangeabl
 
 An example for such a graph can be found below:
 
-```{r 04-pipelines-001, echo=FALSE,fig.align='center'}
+```{r 04-pipelines-001, echo=FALSE, fig.align='center', out.width="98%"}
 knitr::include_graphics("images/simple_pipeline.png")
 ```
 

--- a/bookdown/06-extending.Rmd
+++ b/bookdown/06-extending.Rmd
@@ -316,7 +316,7 @@ We will show a simplified version here, **`PipeOpCopyTwo`**, that creates exactl
 
 The following figure visualizes how our `PipeOp` is situated in the `Pipeline` and the significant in- and outputs.
 
-```{r 06-extending-016, echo=FALSE,fig.align='center'}
+```{r 06-extending-016, echo=FALSE, fig.align='center', out.width="98%"}
 knitr::include_graphics("images/po_multi_viz.png")
 ```
 
@@ -776,4 +776,3 @@ result = gr$train(task)
 
 result[[1]]$data()
 ```
-


### PR DESCRIPTION
Similar to #90 adding three more such adjustments.  Now the pdf has all figures nicely 'visible'.