### PR TITLE
"Code and description in conflict"

### DIFF
--- a/bookdown/06-extending.Rmd
+++ b/bookdown/06-extending.Rmd
@@ -102,7 +102,7 @@ For a simplified `r ref("rpart::rpart()")`, the initialization could look like t
 initialize = function(id = "classif.rpart") {
     ps = ParamSet$new(list(
       ParamDbl$new(id = "cp", default = 0.01, lower = 0, upper = 1, tags = "train"),
-      ParamInt$new(id = "xval", default = 0L, lower = 0L, tags = "train")
+      ParamInt$new(id = "xval", default = 10L, lower = 0L, tags = "train")
     ))
     ps$values = list(xval = 0L)
 
@@ -122,7 +122,7 @@ We only have specified a small subset of the available hyperparameters:
 * The complexity `"cp"` is numeric, its feasible range is `[0,1]`, it defaults to `0.01` and the parameter is used during `"train"`.
 * The complexity `"xval"` is integer, its lower bound `0`, its default is `0` and the parameter is also used during `"train"`.
   Note that we have changed the default here from `10` to `0` to save some computation time.
-  This is **not** done by setting a different `default` in `ParamInt$new()`, but instead by setting the value implicitly.
+  This is **not** done by setting a different `default` in `ParamInt$new()`, but instead by setting the value explicitly.
 
 #### Train function {#learner-train}
 


### PR DESCRIPTION
The text explicitly states that default for `xval = 10L`, but that it should not be set in `ParamInt$new()`, while in the code reads 

```r
initialize = function(id = "classif.rpart") {
      ParamInt$new(id = "xval", default = 0L, lower = 0L, tags = "train")
```
