### PR TITLE
clean travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@
 
 language: r
 dist: bionic
-sudo: true
 cache: packages
 latex: false
 r_github_packages: mlr-org/mlr3book
-pandoc_version: 2.7.3
 
 addons:
   apt:


### PR DESCRIPTION
- `sudo` has no effect anymore
- from my experience we do not need a hardcoded pandoc version. Removing this makes us dynamic to the upstream updates