### PR TITLE
fixing two small typos

### DIFF
--- a/bookdown/03-optimization-tuning.Rmd
+++ b/bookdown/03-optimization-tuning.Rmd
@@ -15,7 +15,7 @@ knitr::include_graphics("images/tuning_process.svg")
 
 At the heart of `r mlr_pkg("mlr3tuning")` are the R6 classes:
 
-* `r ref("TuningInstanceSingleCrit")`, `r ref("TuningInstanceMultiCrit")`: This two classes describe the tuning problem and store the results.
+* `r ref("TuningInstanceSingleCrit")`, `r ref("TuningInstanceMultiCrit")`: These two classes describe the tuning problem and store the results.
 * `r ref("Tuner")`: This class is the base class for implementations of tuning algorithms.
 
 ### The `TuningInstance` Classes {#tuning-optimization}

--- a/bookdown/06-extending-learners.Rmd
+++ b/bookdown/06-extending-learners.Rmd
@@ -244,7 +244,7 @@ p = lrn$predict(task)
 p$confusion
 ```
 
-To ensure that your learners is able to handle all kinds of different properties and feature types, we have written an "autotest" that checks the learner for different combinations of such.
+To ensure that your learner is able to handle all kinds of different properties and feature types, we have written an "autotest" that checks the learner for different combinations of such.
 
 The "autotest" setup is already included in the mlr3learners.template skeleton.
 For some learners that have required parameters, it is needed to set some values for required parameters after construction so that the learner can be run in the first place.


### PR DESCRIPTION
I fixed two small typos: 

1) This two classes -> These two classes

2) To ensure that your learners is able to -> To ensure that your learner is able to


Thanks, 
Damir