### PR TITLE
Build a fresh cache daily

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -21,7 +21,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {
+              os: ubuntu-20.04,
+              r: "release",
+              rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest",
+            }
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -42,14 +42,21 @@ jobs:
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 
-      - name: Cache R packages
+      # set date/week for use in cache creation
+      # https://github.community/t5/GitHub-Actions/How-to-set-and-access-a-Workflow-variable/m-p/42970
+      # - cache R packages daily
+      - name: "[Cache] Prepare daily timestamp for cache"
+        if: runner.os != 'Windows'
+        id: date
+        run: echo "::set-output name=date::$(date '+%d-%m')"
+
+      - name: "[Cache] Cache R packages"
         if: runner.os != 'Windows'
         uses: pat-s/always-upload-cache@v2.1.0
-
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}
+          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}
 
       - name: Install system dependencies
         if: runner.os == 'Linux'


### PR DESCRIPTION
As in all other repos.

If we are in a broken cache state (like one package is ahead, e.g. using a devel version), we can't escape and subsequent CRAN version won't be installed.
Building a daily cache solves the problem.