### PR TITLE
fix build after sf 1.0 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,6 +64,7 @@ Suggests:
     praznik,
     precrec,
     ranger,
+    rgdal,
     rpart,
     RSQLite,
     servr,
@@ -73,9 +74,9 @@ Suggests:
     svglite,
     xgboost
 Remotes:
-    mlr-org/mlr3verse,
     mlr-org/mlr3db,
-    mlr-org/mlr3extralearners
+    mlr-org/mlr3extralearners,
+    mlr-org/mlr3verse
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1

--- a/bookdown/08-interpretation-dalex.Rmd
+++ b/bookdown/08-interpretation-dalex.Rmd
@@ -133,7 +133,7 @@ model %>%
   plot()
 ```
 
-1. All functions in the DALEX package can work for models with any structure. It is possible because in the first step we create an adapter that allows the downstream functions to access the model in a consistent fashion. In general, such an adapter is created with `r ref("DALEX::explain()")` function, but for models created in the `mlr3` package it is more convenient to use the `r ref("DALEXtra::explain_mlr3()")`.
+1. All functions in the DALEX package can work for models with any structure. It is possible because in the first step we create an adapter that allows the downstream functions to access the model in a consistent fashion. In general, such an adapter is created with `r ref("DALEX::explain.default()")` function, but for models created in the `mlr3` package it is more convenient to use the `r ref("DALEXtra::explain_mlr3()")`.
 
 2. Explanations are determined by the functions `r ref("DALEX::model_parts()")`, `r ref("DALEX::model_profile()")`, `r ref("DALEX::predict_parts()")` and `r ref("DALEX::predict_profile()")`. Each of these functions takes the model adapter as its first argument. The other arguments describe how the function works. We will present them in the following section.
 
@@ -141,7 +141,7 @@ model %>%
 
 We show this cascade of functions based on the FIFA example.
 
-To get started with the exploration of the model behaviour we need to create an explainer. `r ref("DALEX::explain")` function handles is for all types of predictive models. In the `r cran_pkg("DALEXtra")` package there generic versions for the most common ML frameworks. Among them the `r ref("DALEXtra::explain_mlr3()")` function works for `mlr3` models.
+To get started with the exploration of the model behaviour we need to create an explainer. `r ref("DALEX::explain.default")` function handles is for all types of predictive models. In the `r cran_pkg("DALEXtra")` package there generic versions for the most common ML frameworks. Among them the `r ref("DALEXtra::explain_mlr3()")` function works for `mlr3` models.
 
 This function performs a series of internal checks so the output is a bit verbose. Turn the `verbose = FALSE` argument to make it less wordy.
 


### PR DESCRIPTION
{rgdal} is required for some functionality in {mlr3spatiotempcv}, more specifically in {blockCV} to work