### PR TITLE
remove redundant image link

### DIFF
--- a/bookdown/01-intro.Rmd
+++ b/bookdown/01-intro.Rmd
@@ -77,14 +77,10 @@ Additionally, the following packages are suggested for extra functionality:
 * To capture output, warnings, and exceptions, `r cran_pkg("evaluate")` and `r cran_pkg("callr")` can be used.
 
 
-While `r mlr_pkg("mlr3")` provides the base functionality and some of the most fundamental building blocks for machine learning, the following packages extend `r mlr_pkg("mlr3")` with capabilities for preprocessing, pipelining, visualizations, additional learners or additional task types:
+While `r mlr_pkg("mlr3")` provides the base functionality and some of the most fundamental building blocks for machine learning, the following packages extend `r mlr_pkg("mlr3")` with capabilities for preprocessing, pipelining, visualizations, additional learners or additional task types (click to enlarge):
 
-```{r 01-intro-001, echo = FALSE, fig.align='center', out.width="98%", eval=knitr::is_html_output()}
+```{r 01-intro-001, echo = FALSE, fig.align='center', out.width="98%", eval=knitr::is_html_output(), fig.link='https://raw.githubusercontent.com/mlr-org/mlr3/master/man/figures/mlr3verse.svg'}
 knitr::include_graphics("https://raw.githubusercontent.com/mlr-org/mlr3/master/man/figures/mlr3verse.svg")
-```
-
-```{asis 01-intro-001a, echo = TRUE, fig.align='center', out.width="98%", eval=knitr::is_latex_output(), results='asis'}
-To view the mlr3verse image for an overview of the mlr3 package ecosystem follow this link: https://raw.githubusercontent.com/mlr-org/mlr3/master/man/figures/mlr3verse.svg.
 ```
 
 A complete list with links to the respective repositories can be found on the [wiki page on extension packages](https://github.com/mlr-org/mlr3/wiki/Extension-Packages).


### PR DESCRIPTION
Change the end of 01: remove the part `To view the mlr3verse image...`; instead make the mlr3 ecosystem image itself into a link to itself and add the hint `click to enlarge`.