### PR TITLE
Working on Chapter 2.4 Train, Predict, Performance

### DIFF
--- a/book/02-basics-learners.qmd
+++ b/book/02-basics-learners.qmd
@@ -28,10 +28,10 @@ knitr::include_graphics("images/learner.svg")
 The `r mlr3book::mlr_pkg("mlr3")` package ships with the following set of classification and regression learners.
 We deliberately keep this small to avoid unnecessary dependencies:
 
-* `r ref("mlr_learners_classif.featureless")`: Simple baseline classification learner.
-  The default is to predict the label that is most frequent in the training set every time. While this is not very useful by itself, it can be used as a "[fallback learner](fallback-learners)" to make predictions in case another, more sophisticated, learner failed for some reason.
-* `r ref("mlr_learners_regr.featureless")`: Simple baseline regression learner.
-  The default is to predict the mean of the target in training set every time. Similar to `r ref("mlr_learners_classif.featureless")`, it makes for a good "[fallback learner](fallback-learners)"
+* `r ref("mlr_learners_classif.featureless")`: Simple baseline classification learner (inheriting from `r ref("LearnerClassif")`).
+  The default is to predict the label that is most frequent in the training set every time.
+* `r ref("mlr_learners_regr.featureless")`: Simple baseline regression learner (inheriting from `r ref("LearnerRegr")`).
+  The default is to predict the mean of the target in training set every time.
 * `r ref("mlr_learners_classif.rpart")`: Single classification tree from package `r mlr3book::cran_pkg("rpart")`.
 * `r ref("mlr_learners_regr.rpart")`: Single regression tree from package `r mlr3book::cran_pkg("rpart")`.
 

--- a/book/02-basics-learners.qmd
+++ b/book/02-basics-learners.qmd
@@ -28,10 +28,10 @@ knitr::include_graphics("images/learner.svg")
 The `r mlr3book::mlr_pkg("mlr3")` package ships with the following set of classification and regression learners.
 We deliberately keep this small to avoid unnecessary dependencies:
 
-* `r ref("mlr_learners_classif.featureless")`: Simple baseline classification learner (inheriting from `r ref("LearnerClassif")`).
-  The default is to predict the label that is most frequent in the training set every time.
-* `r ref("mlr_learners_regr.featureless")`: Simple baseline regression learner (inheriting from `r ref("LearnerRegr")`).
-  The default is to predict the mean of the target in training set every time.
+* `r ref("mlr_learners_classif.featureless")`: Simple baseline classification learner.
+  The default is to predict the label that is most frequent in the training set every time. While this is not very useful by itself, it can be used as a "[fallback learner](fallback-learners)" to make predictions in case another, more sophisticated, learner failed for some reason.
+* `r ref("mlr_learners_regr.featureless")`: Simple baseline regression learner.
+  The default is to predict the mean of the target in training set every time. Similar to `r ref("mlr_learners_classif.featureless")`, it makes for a good "[fallback learner](fallback-learners)"
 * `r ref("mlr_learners_classif.rpart")`: Single classification tree from package `r mlr3book::cran_pkg("rpart")`.
 * `r ref("mlr_learners_regr.rpart")`: Single regression tree from package `r mlr3book::cran_pkg("rpart")`.
 

--- a/book/02-basics-train-predict.qmd
+++ b/book/02-basics-train-predict.qmd
@@ -222,5 +222,5 @@ task = tsk("penguins")
 learner = lrn("classif.rpart", predict_type = "prob")
 learner$train(task)
 prediction = learner$predict(task)
-autoplot(prediction)
+ggplot2::autoplot(prediction)
 ```

--- a/book/02-basics-train-predict.qmd
+++ b/book/02-basics-train-predict.qmd
@@ -8,32 +8,14 @@ library(mlr3book)
 In this section, we explain how [tasks](#tasks) and [learners](#learners) can be used to train a model and predict on a new dataset.
  Training a [learner](#learners) means fitting a model to a given data set -- essentially an optimization problem that determines the best parameters (not hyperparameters!) of the model given the data.
 We then [predict](#predicting) the label for observations that the model has not seen during training.
-In the next chapter, we will then go over comparing the predictions to ground truth values in order to assess the predictive performance of the model.
+We will then go over comparing the predictions to ground truth values in order to manually assess the predictive performance of the model.
 
-The concept is demonstrated on a supervised classification task using the `r ref("mlr_tasks_penguins", text = "penguins")` dataset and the `r ref("mlr_learners_classif.rpart", text = "rpart")` learner, which builds a classification tree. As shown in the previous chapters, we load these objects using the short access functions `r ref("tsk()")` and  `r ref("lrn()")`.
+The concept is demonstrated on a supervised classification task using the `r ref("mlr_tasks_pima", text = "pima")` dataset, in which patient data is used to diagnostically predict diabetes, and the `r ref("mlr_learners_classif.rpart", text = "rpart")` learner, which builds a classification tree. As shown in the previous chapters, we load these objects using the short access functions `r ref("tsk()")` and  `r ref("lrn()")`.
 
 ```{r 02-basics-train-predict-003}
-task = tsk("penguins")
+task = tsk("pima")
 learner = lrn("classif.rpart")
 ```
-
-## Setting up the train/test splits of the data {#split-data}
-
-When evaluating the performance of a `r ref("Learner")`, it is important to score predictions made on data that have not been seen during training, since making predictions on training data is very easy in general -- a `r ref("Learner")` could just memorize the the training data responses and get a perfect score.
-
-We therefore first create a vector indicating on what row IDs of the task the `r ref("Learner")` should be trained, and another that indicates the remaining rows that should be used for prediction. These vectors indicate the train-test-split we are using. This is done manually here for demonstration purpuses: In @sec-resampling, we show how `r mlr3book::mlr_pkg("mlr3")` can automatically create training and test sets based on resampling strategies that can be more elaborate.
-
-We use 80% of all available observations to train and predict on the remaining 20%.
-
-```{r 02-basics-train-predict-004}
-set.seed(7)
-train_set = sample(task$row_ids, 0.8 * task$nrow)
-test_set = setdiff(task$row_ids, train_set)
-```
-
-:::{.callout-caution}
-Do not use constructs like `sample(task$nrow, ...)`, for the purpose of creating task subsets, since rows are always identified by their `$row_ids`, which are not guaranteed to range from 1 to `task$nrow`: they could be any positive integer.
-:::
 
 ## Training the learner {#training}
 
@@ -47,7 +29,7 @@ learner$model
 Now we fit the classification tree using the training set of the task by calling the `$train()` method of `r ref("Learner")`:
 
 ```{r 02-basics-train-predict-006}
-learner$train(task, row_ids = train_set)
+learner$train(task)
 ```
 
 This operation modifies the learner in-place by adding the fitted model to the existing object.
@@ -57,39 +39,50 @@ We can now access the stored model via the field `$model`:
 learner$model
 ```
 
-Inspecting the output, we see that the learner has identified features in the task that are predictive of the class (the type of penguin) and uses them to partition observations in the tree.
+Inspecting the output, we see that the learner has identified features in the task that are predictive of the class (diabetes status) and uses them to partition observations in the tree.
 There are additional details on how the data is partitioned across branches of the tree; the textual representation of the model depends on the type of learner.
 For more information on this particular type of model, see `r ref ("rpart::print.rpart()")`.
 
 ## Predicting {#predicting}
 
-After the model has been fitted to the training data, we use the test set for prediction.
-Remember that we [initially split the data](#split-data) in `train_set` and `test_set`.
+After the model has been fitted to the training data, we can now use it for prediction. A common case is that a model was fitted on all training data that was available, and should now be used to make predictions for new data for which the actual labels are unknown:
+
+```{r 02-basics-train-predict-new-001}
+pima_new = data.table::fread("
+age, glucose, insulin, mass, pedigree, pregnant, pressure, triceps
+24,  145,     306,     41.7, 0.5,      3,        52,       36
+47,  133,     NA,      23.3, 0.2,      7,        83,       28
+")
+pima_new
+```
+
+The learner does not need to know any more meta-information about this data to make a prediction, such as which columns are features and which are targets, since this was already included in the training task. Instead, this data can directly be used to make a prediction using `$predict_newdata()`:
 
 ```{r 02-basics-train-predict-008}
-prediction = learner$predict(task, row_ids = test_set)
+prediction = learner$predict_newdata(pima_new)
 prediction
 ```
 
-The `$predict()` method of the `r ref("Learner")` returns a `r ref("Prediction")` object.
-More precisely, a `r ref("LearnerClassif")` returns a `r ref("PredictionClassif")` object.
-
-A prediction objects holds the row IDs of the test data, the respective true label of the target column and the respective predictions.
-The simplest way to extract this information is by converting the `r ref("Prediction")` object to a `data.table()`:
-
+This method returns a `r ref("Prediction")` object.
+More precisely, because the `learner` is a `r ref("LearnerClassif")`, it returns a `r ref("PredictionClassif")` object. The easiest way to access information from it is to convert it to a `data.table`:
 ```{r 02-basics-train-predict-009}
-head(as.data.table(prediction)) # show first six predictions
+as.data.table(prediction)
 ```
 
-For classification, you can also extract the confusion matrix:
+Here the `"truth"` column is `NA`, since it is not known. Should the actual truth values for the new data be known, then one can convert this data to a new `r ref("Task")`, create predictions that know both the predicted and the actual label, and use this prediction object for performance evaluation.
 
-```{r 02-basics-train-predict-010}
-prediction$confusion
+Suppose the `pima_new` data had both been measured on positive (`"pos"`) patients:
+```{r 02-basics-train-predict-new-002}
+pima_new_known = cbind(pima_new, diabetes = factor("pos", levels = c("pos", "neg")))
+pima_new_known
+task_pima_new = as_task_classif(pima_new_known, target = "diabetes")
 ```
 
-The confusion matrix shows, for each class, how many observations were predicted to be in that class and how many were actually in it (more information on [Wikipedia](https://en.wikipedia.org/wiki/Confusion_matrix)).
-The entries along the diagonal denote the correctly classified observations.
-In this case, we can see that our classifier is really quite good and correctly predicting almost all observations.
+This task can then be used to make a prediction using the `$predict()` method of the `r ref("Learner")` class. The result is another `r ref("PredictionClassif")`, but with the `"truth"` column filled out:
+```{r 02-basics-train-predict-008}
+prediction = learner$predict(task_pima_new)
+prediction
+```
 
 ## Changing the Predict Type {#predict-type}
 
@@ -101,10 +94,10 @@ To predict these probabilities, the `predict_type` field of a `r ref("LearnerCla
 learner$predict_type = "prob"
 
 # re-fit the model
-learner$train(task, row_ids = train_set)
+learner$train(task)
 
 # rebuild prediction object
-prediction = learner$predict(task, row_ids = test_set)
+prediction = learner$predict(task_pima_new)
 
 prediction
 ```
@@ -113,13 +106,13 @@ The prediction object now contains probabilities for all class labels in additio
 
 ```{r 02-basics-train-predict-012}
 # directly access the predicted labels:
-head(prediction$response)
+prediction$response
 
 # directly access the matrix of probabilities:
-head(prediction$prob)
+prediction$prob
 
 # data.table conversion
-head(as.data.table(prediction)) # show first six
+as.data.table(prediction)
 ```
 
 Similarly to predicting probabilities for classification, many `r ref("LearnerRegr", text = "regression learners")` support the extraction of standard error estimates for predictions by setting the predict type to `"se"`.
@@ -129,23 +122,89 @@ Similarly to predicting probabilities for classification, many `r ref("LearnerRe
 Models trained on binary classification tasks that predict the probability for the positive class usually use a simple rule to determine the predicted class label: if the probability is more than 50%, predict the positive label, otherwise predict the negative label.
 In some cases you may want to adjust this threshold, for example if the classes are very unbalanced (i.e. one is much more prevalent than the other).
 
-In the example below, we change the threshold to 0.2, which improves the True Positive Rate (TPR).
-Note that while the new threshold classifies more observations from the positive class correctly, the True Negative Rate (TNR) decreases.
-Depending on the application, this may or may not be desired.
+In the example below, we change the threshold to 0.2, making the model predict `"pos"` for both example rows:
 
 ```{r 02-basics-learners-010}
-data("Sonar", package = "mlbench")
-task = as_task_classif(Sonar, target = "Class", positive = "M")
-learner = lrn("classif.rpart", predict_type = "prob")
-pred = learner$train(task)$predict(task)
+prediction$set_threshold(0.2)
+prediction
+```
 
-measures = msrs(c("classif.tpr", "classif.tnr")) # use msrs() to get a list of multiple measures
-pred$confusion
-pred$score(measures)
+## Predicting on known data and train/test splits
 
-pred$set_threshold(0.2)
-pred$confusion
-pred$score(measures)
+We will usually not want to wait with performance evaluation until new data becomes available and will instead work with all the training data we have available at a given point. However, when evaluating the performance of a `r ref("Learner")`, it is also important to score predictions made on data that have not been seen during training, since making predictions on training data is too easy in general -- a `r ref("Learner")` could just memorize the the training data responses and get a perfect score.
+
+`r mlr3book::mlr_pkg("mlr3")` makes it easy to only train on subsets of given tasks. We first create a vector indicating on what row IDs of the task the `r ref("Learner")` should be trained, and another that indicates the remaining rows that should be used for prediction. These vectors indicate the train-test-split we are using. This is done manually here for demonstration purpuses: In @sec-resampling, we show how `r mlr3book::mlr_pkg("mlr3")` can automatically create training and test sets based on resampling strategies that can be more elaborate.
+
+We will use 67% of all available observations to train and predict on the remaining 33%.
+
+```{r 02-basics-train-predict-004}
+set.seed(7)
+train_set = sample(task$row_ids, 0.67 * task$nrow)
+test_set = setdiff(task$row_ids, train_set)
+```
+
+:::{.callout-caution}
+Do not use constructs like `sample(task$nrow, ...)` for the purpose of creating task subsets, since rows are always identified by their `$row_ids`. These are not guaranteed to range from 1 to `task$nrow` and could be any positive integer.
+:::
+
+Both `$train()` and `$predict()` have an optional `row_ids`-argument that determines which rows are used. Note that it is not a problem to run `$train()` with a `r ref("Learner")` that has already been trained: the old model is automatically discarded, the learner trains from scratch.
+
+```{r 02-basics-train-predict-006}
+# train on the training set
+learner$train(task, row_ids = train_set)
+
+# predict on the test set
+prediction = learner$predict(task, row_ids = test_set)
+
+# the prediction naturally knows about the "truth" from the task
+prediction
+```
+
+## Performance assessment {#measure}
+
+The last step of modeling is usually assessing the performance of the trained model. For this, the predictions made by the model are compared with the known ground-truth values that are stored in the `r ref("Prediction")` object.
+The exact nature of this comparison is defined by a measure, which is given by a `"Measure"` object.
+If the prediction was made on a dataset without the target column, i.e. without known true labels, then performance can not be calculated.
+
+Available measures can be retrieved using the `r ref("msr()")` function, which accesses objects in `r ref("mlr_measures")`:
+
+```{r 02-basics-train-predict-014}
+mlr_measures
+```
+
+We choose accuracy (`r ref("mlr_measures_classif.acc", text = "classif.acc")`) as our specific performance measure here and call the method `$score()` of the `prediction` object to quantify the predictive performance of our model.
+
+```{r 02-basics-train-predict-015}
+measure = msr("classif.acc")
+measure
+prediction$score(measure)
+```
+
+:::{.callout-note}
+`$score()` can called without a given measure. In this case, classification defaults to classification error (`r ref("mlr_measures_classif.ce", text = "classif.ce")`, which is one minus accuracy) and regression to the mean squared error (`r ref("mlr_measures_regr.mse", text = "regr.mse")`).
+:::
+
+It is possible to calculate multiple measures at the same time by passing a list to `$score()`. Such a list can easily be constructed using the "plural" `msrs()` function. If one wanted to have both the "true positive rate" (`"classif.tpr"`) and the "true negative rate" (`"classif.tnr"`), one would use:
+
+```{r 02-basics-train-predict-015-2}
+measures = msrs(c("classif.tpr", "classif.tnr"))
+prediction$score(measures)
+```
+
+### Confusion Matrix
+
+A special case of performance evaluation is the confusion matrix, which shows, for each class, how many observations were predicted to be in that class and how many were actually in it (more information on [Wikipedia](https://en.wikipedia.org/wiki/Confusion_matrix)).
+The entries along the diagonal denote the correctly classified observations.
+
+```{r 02-basics-train-predict-010}
+prediction$confusion
+```
+
+In this case, we can see that our classifier seems to misclassify a relatively large number of positive samples as negative. In fact, a positive case is still more likely to be classified as `"neg"` than `"pos'`. Depending on the application being considered, it is possible that it is more important to keep false positives (lower left element of the confusion matrix) low. Lowering the threshold, so that ambiguous samples are more readily classified as positive rather than negative, can help in this case, although it will also lead to negative cases being classified as `"pos"` more often. 
+
+```{r 02-basics-train-predict-010-2}
+prediction$set_threshold(0.3)
+prediction$confusion
 ```
 
 :::{.callout-tip}
@@ -165,31 +224,3 @@ learner$train(task)
 prediction = learner$predict(task)
 autoplot(prediction)
 ```
-
-## Performance assessment {#measure}
-
-The last step of modeling is usually assessing the performance of the trained model.
-We have already had a look at this with the confusion matrix, but it is often convenient to quantify the performance of a model with a single number.
-The exact nature of this comparison is defined by a measure, which is given by a `"Measure"` object.
-
-:::{.callout-warning}
-If the prediction was made on a dataset without the target column, i.e. without known true labels, then no performance can be calculated.
-:::
-
-Available measures are stored in `r ref("mlr_measures")` (with convenience getter function `r ref("msr()")`):
-
-```{r 02-basics-train-predict-014}
-mlr_measures
-```
-
-We choose accuracy (`r ref("mlr_measures_classif.acc", text = "classif.acc")`) as our specific performance measure here and call the method `$score()` of the `prediction` object to quantify the predictive performance of our model.
-
-```{r 02-basics-train-predict-015}
-measure = msr("classif.acc")
-print(measure)
-prediction$score(measure)
-```
-
-:::{.callout-note}
-If no measure is specified, classification defaults to classification error (`r ref("mlr_measures_classif.ce", text = "classif.ce")`, the inverse of accuracy) and regression to the mean squared error (`r ref("mlr_measures_regr.mse", text = "regr.mse")`).
-:::

--- a/book/02-basics-train-predict.qmd
+++ b/book/02-basics-train-predict.qmd
@@ -131,7 +131,7 @@ prediction
 
 ## Predicting on known data and train/test splits
 
-We will usually not want to wait with performance evaluation until new data becomes available and will instead work with all the training data we have available at a given point. However, when evaluating the performance of a `r ref("Learner")`, it is also important to score predictions made on data that have not been seen during training, since making predictions on training data is too easy in general -- a `r ref("Learner")` could just memorize the the training data responses and get a perfect score.
+We will usually not want to wait with performance evaluation until new data becomes available and will instead work with all the training data we have available at a given point. However, when evaluating the performance of a `r ref("Learner")`, it is also important to score predictions made on data that have not been seen during training, since making predictions on training data is too easy in general -- a `r ref("Learner")` could just memorize the training data responses and get a perfect score.
 
 `r mlr3book::mlr_pkg("mlr3")` makes it easy to only train on subsets of given tasks. We first create a vector indicating on what row IDs of the task the `r ref("Learner")` should be trained, and another that indicates the remaining rows that should be used for prediction. These vectors indicate the train-test-split we are using. This is done manually here for demonstration purpuses: In @sec-resampling, we show how `r mlr3book::mlr_pkg("mlr3")` can automatically create training and test sets based on resampling strategies that can be more elaborate.
 

--- a/book/02-basics-train-predict.qmd
+++ b/book/02-basics-train-predict.qmd
@@ -8,7 +8,7 @@ library(mlr3book)
 In this section, we explain how [tasks](#tasks) and [learners](#learners) can be used to train a model and predict on a new dataset.
  Training a [learner](#learners) means fitting a model to a given data set -- essentially an optimization problem that determines the best parameters (not hyperparameters!) of the model given the data.
 We then [predict](#predicting) the label for observations that the model has not seen during training.
-We will then go over comparing the predictions to ground truth values in order to manually assess the predictive performance of the model.
+We will then go over comparing the predictions to ground truth values in order to assess the quality of a prediction.
 
 The concept is demonstrated on a supervised classification task using the `r ref("mlr_tasks_pima", text = "pima")` dataset, in which patient data is used to diagnostically predict diabetes, and the `r ref("mlr_learners_classif.rpart", text = "rpart")` learner, which builds a classification tree. As shown in the previous chapters, we load these objects using the short access functions `r ref("tsk()")` and  `r ref("lrn()")`.
 

--- a/book/02-basics-train-predict.qmd
+++ b/book/02-basics-train-predict.qmd
@@ -149,7 +149,7 @@ Do not use constructs like `sample(task$nrow, ...)` for the purpose of creating 
 
 Both `$train()` and `$predict()` have an optional `row_ids`-argument that determines which rows are used. Note that it is not a problem to run `$train()` with a `r ref("Learner")` that has already been trained: the old model is automatically discarded, the learner trains from scratch.
 
-```{r 02-basics-train-predict-006}
+```{r 02-basics-train-predict-006-2}
 # train on the training set
 learner$train(task, row_ids = train_set)
 

--- a/book/02-basics-train-predict.qmd
+++ b/book/02-basics-train-predict.qmd
@@ -6,7 +6,7 @@ library(mlr3book)
 ```
 
 In this section, we explain how [tasks](#tasks) and [learners](#learners) can be used to train a model and predict on a new dataset.
-The concept is demonstrated on a supervised classification task using the `r ref("mlr_tasks_penguins", text = "penguins")` dataset and the `r ref("mlr_learners_classif.rpart", text = "rpart")` learner, which builds a single classification tree.
+The concept is demonstrated on a supervised classification task using the `r ref("mlr_tasks_penguins", text = "penguins")` dataset and the `r ref("mlr_learners_classif.rpart", text = "rpart")` learner, which builds a classification tree.
 
 Training a [learner](#learners) means fitting a model to a given data set -- essentially an optimization problem that determines the best parameters (not hyperparameters!) of the model given the data.
 We then [predict](#predicting) the label for observations that the model has not seen during training.

--- a/book/02-basics-train-predict.qmd
+++ b/book/02-basics-train-predict.qmd
@@ -8,7 +8,7 @@ library(mlr3book)
 In this section, we explain how [tasks](#tasks) and [learners](#learners) can be used to train a model and predict on a new dataset.
  Training a [learner](#learners) means fitting a model to a given data set -- essentially an optimization problem that determines the best parameters (not hyperparameters!) of the model given the data.
 We then [predict](#predicting) the label for observations that the model has not seen during training.
-These [predictions](#predicting) are compared to the ground truth values in order to assess the predictive performance of the model.
+In the next chapter, we will then go over comparing the predictions to ground truth values in order to assess the predictive performance of the model.
 
 The concept is demonstrated on a supervised classification task using the `r ref("mlr_tasks_penguins", text = "penguins")` dataset and the `r ref("mlr_learners_classif.rpart", text = "rpart")` learner, which builds a classification tree. As shown in the previous chapters, we load these objects using the short access functions `r ref("tsk()")` and  `r ref("lrn()")`.
 
@@ -26,6 +26,7 @@ We therefore first create a vector indicating on what row IDs of the task the `r
 We use 80% of all available observations to train and predict on the remaining 20%.
 
 ```{r 02-basics-train-predict-004}
+set.seed(7)
 train_set = sample(task$row_ids, 0.8 * task$nrow)
 test_set = setdiff(task$row_ids, train_set)
 ```
@@ -53,7 +54,7 @@ This operation modifies the learner in-place by adding the fitted model to the e
 We can now access the stored model via the field `$model`:
 
 ```{r 02-basics-train-predict-007}
-print(learner$model)
+learner$model
 ```
 
 Inspecting the output, we see that the learner has identified features in the task that are predictive of the class (the type of penguin) and uses them to partition observations in the tree.
@@ -67,7 +68,7 @@ Remember that we [initially split the data](#split-data) in `train_set` and `tes
 
 ```{r 02-basics-train-predict-008}
 prediction = learner$predict(task, row_ids = test_set)
-print(prediction)
+prediction
 ```
 
 The `$predict()` method of the `r ref("Learner")` returns a `r ref("Prediction")` object.
@@ -104,19 +105,21 @@ learner$train(task, row_ids = train_set)
 
 # rebuild prediction object
 prediction = learner$predict(task, row_ids = test_set)
+
+prediction
 ```
 
 The prediction object now contains probabilities for all class labels in addition to the predicted label (the one with the highest probability):
 
 ```{r 02-basics-train-predict-012}
-# data.table conversion
-head(as.data.table(prediction)) # show first six
-
 # directly access the predicted labels:
 head(prediction$response)
 
 # directly access the matrix of probabilities:
 head(prediction$prob)
+
+# data.table conversion
+head(as.data.table(prediction)) # show first six
 ```
 
 Similarly to predicting probabilities for classification, many `r ref("LearnerRegr", text = "regression learners")` support the extraction of standard error estimates for predictions by setting the predict type to `"se"`.

--- a/book/02-basics-train-predict.qmd
+++ b/book/02-basics-train-predict.qmd
@@ -19,16 +19,20 @@ learner = lrn("classif.rpart")
 
 ## Setting up the train/test splits of the data {#split-data}
 
-It is common to train on a majority of the data, to give the learner a better chance of fitting a good model.
-Here we use 80% of all available observations to train and predict on the remaining 20%.
-For this purpose, we create two index vectors:
+When evaluating the performance of a `r ref("Learner")`, it is important to score predictions made on data that have not been seen during training, since making predictions on training data is very easy in general -- a `r ref("Learner")` could just memorize the the training data responses and get a perfect score.
+
+We therefore first create a vector indicating on what row IDs of the task the `r ref("Learner")` should be trained, and another that indicates the remaining rows that should be used for prediction. These vectors indicate the train-test-split we are using. This is done manually here for demonstration purpuses: In @sec-resampling, we show how `r mlr3book::mlr_pkg("mlr3")` can automatically create training and test sets based on resampling strategies that can be more elaborate.
+
+We use 80% of all available observations to train and predict on the remaining 20%.
 
 ```{r 02-basics-train-predict-004}
-train_set = sample(task$nrow, 0.8 * task$nrow)
-test_set = setdiff(seq_len(task$nrow), train_set)
+train_set = sample(task$row_ids, 0.8 * task$nrow)
+test_set = setdiff(task$row_ids, train_set)
 ```
 
-In @sec-resampling we show how `r mlr3book::mlr_pkg("mlr3")` can automatically create training and test sets based on different [resampling](#resampling) strategies.
+:::{.callout-caution}
+Do not use constructs like `sample(task$nrow, ...)`, for the purpose of creating task subsets, since rows are always identified by their `$row_ids`, which are not guaranteed to range from 1 to `task$nrow`: they could be any positive integer.
+:::
 
 ## Training the learner {#training}
 

--- a/book/02-basics-train-predict.qmd
+++ b/book/02-basics-train-predict.qmd
@@ -6,20 +6,11 @@ library(mlr3book)
 ```
 
 In this section, we explain how [tasks](#tasks) and [learners](#learners) can be used to train a model and predict on a new dataset.
-The concept is demonstrated on a supervised classification task using the `r ref("mlr_tasks_penguins", text = "penguins")` dataset and the `r ref("mlr_learners_classif.rpart", text = "rpart")` learner, which builds a classification tree.
-
-Training a [learner](#learners) means fitting a model to a given data set -- essentially an optimization problem that determines the best parameters (not hyperparameters!) of the model given the data.
+ Training a [learner](#learners) means fitting a model to a given data set -- essentially an optimization problem that determines the best parameters (not hyperparameters!) of the model given the data.
 We then [predict](#predicting) the label for observations that the model has not seen during training.
 These [predictions](#predicting) are compared to the ground truth values in order to assess the predictive performance of the model.
 
-## Creating Task and Learner Objects {#train-predict-objects}
-
-First of all, we load the `r mlr3book::mlr_pkg("mlr3verse")` package, which will load all other packages we need here.
-```{r 02-basics-train-predict-002}
-library("mlr3verse")
-```
-
-Now, we retrieve the task and the learner from `r ref("mlr_tasks")` (with shortcut `r ref("tsk()")`) and `r ref("mlr_learners")` (with shortcut `r ref("lrn()")`), respectively:
+The concept is demonstrated on a supervised classification task using the `r ref("mlr_tasks_penguins", text = "penguins")` dataset and the `r ref("mlr_learners_classif.rpart", text = "rpart")` learner, which builds a classification tree. As shown in the previous chapters, we load these objects using the short access functions `r ref("tsk()")` and  `r ref("lrn()")`.
 
 ```{r 02-basics-train-predict-003}
 task = tsk("penguins")

--- a/book/02-basics-train-predict.qmd
+++ b/book/02-basics-train-predict.qmd
@@ -222,5 +222,7 @@ task = tsk("penguins")
 learner = lrn("classif.rpart", predict_type = "prob")
 learner$train(task)
 prediction = learner$predict(task)
-ggplot2::autoplot(prediction)
+
+library("mlr3viz")
+autoplot(prediction)
 ```

--- a/book/02-basics-train-predict.qmd
+++ b/book/02-basics-train-predict.qmd
@@ -126,6 +126,35 @@ head(prediction$prob)
 
 Similarly to predicting probabilities for classification, many `r ref("LearnerRegr", text = "regression learners")` support the extraction of standard error estimates for predictions by setting the predict type to `"se"`.
 
+## Thresholding
+
+Models trained on binary classification tasks that predict the probability for the positive class usually use a simple rule to determine the predicted class label: if the probability is more than 50%, predict the positive label, otherwise predict the negative label.
+In some cases you may want to adjust this threshold, for example if the classes are very unbalanced (i.e. one is much more prevalent than the other).
+
+In the example below, we change the threshold to 0.2, which improves the True Positive Rate (TPR).
+Note that while the new threshold classifies more observations from the positive class correctly, the True Negative Rate (TNR) decreases.
+Depending on the application, this may or may not be desired.
+
+```{r 02-basics-learners-010}
+data("Sonar", package = "mlbench")
+task = as_task_classif(Sonar, target = "Class", positive = "M")
+learner = lrn("classif.rpart", predict_type = "prob")
+pred = learner$train(task)$predict(task)
+
+measures = msrs(c("classif.tpr", "classif.tnr")) # use msrs() to get a list of multiple measures
+pred$confusion
+pred$score(measures)
+
+pred$set_threshold(0.2)
+pred$confusion
+pred$score(measures)
+```
+
+:::{.callout-tip}
+Thresholds can be tuned automatically with the `r mlr3book::mlr_pkg("mlr3pipelines")` package, i.e. using `r ref("mlr_pipeops_tunethreshold", text = "PipeOpTuneThreshold")`.
+:::
+
+
 ## Plotting Predictions {#autoplot-prediction}
 
 Similarly to [plotting tasks](#autoplot-task), `r mlr3book::mlr_pkg("mlr3viz")` provides an `r ref("ggplot2::autoplot()", text = "autoplot()")` method for `r ref("Prediction")` objects.

--- a/book/02-basics-train-predict.qmd
+++ b/book/02-basics-train-predict.qmd
@@ -79,7 +79,7 @@ task_pima_new = as_task_classif(pima_new_known, target = "diabetes")
 ```
 
 This task can then be used to make a prediction using the `$predict()` method of the `r ref("Learner")` class. The result is another `r ref("PredictionClassif")`, but with the `"truth"` column filled out:
-```{r 02-basics-train-predict-008}
+```{r 02-basics-train-predict-008-2}
 prediction = learner$predict(task_pima_new)
 prediction
 ```

--- a/book/03-perf.qmd
+++ b/book/03-perf.qmd
@@ -5,14 +5,13 @@ library(mlr3)
 library(mlr3book)
 ```
 
-Now that we are familiar with the basics of how to create tasks and learners, how to fit models, and do some basic performance evaluation, let's have a look at some of the details, and in particular how `r mlr3book::mlr_pkg("mlr3")` makes it easy to perform many common machine learning steps.
+Now that we are familiar with the basics of how to create tasks and learners, how to fit models, let's have a look at some of the details, and in particular how `r mlr3book::mlr_pkg("mlr3")` makes it easy to perform many common machine learning steps.
 
 We will cover the following topics:
 
-## Binary classification and ROC curves
+## Performance Scoring
 
-[Binary classification](#binary-classification) is a special case of classification where the target variable to predict has only two possible values.
-In this case, additional considerations apply; in particular [ROC curves](#binary-roc) and the threshold of where to predict one class versus the other.
+
 
 ## Resampling {#sec-perf-resampling}
 


### PR DESCRIPTION
Can be reviewed now. Changes:
* use pima instead of penguins task now, since this can more easily be used to explain binary class things
* moved train-test-split much further down, before performance assessment / measures.
* instead we now explain training on all data first, then explain `predict_newdata()` (which wasn't there before), then explain prediction on an entirely new task
* and then we explain thresholding, which was moved in from the "learners" chapter.
* explaining reasoning behind train-test-split more thoroughly, also added warning about not using `1:task$nrow`
* the confusion matrix part of the 'thresholding' subsection, pulled in from the 'learners' chapter, comes after 'performance assessment' now