### PR TITLE
Working on Chapter 2.3 Learners

### DIFF
--- a/book/02-basics-learners.qmd
+++ b/book/02-basics-learners.qmd
@@ -3,6 +3,7 @@
 ```{r 02-basics-learners-001, include = F}
 library(mlr3)
 library(mlr3book)
+library("mlr3learners")
 ```
 
 Objects of class `r ref("Learner")` provide a unified interface to many popular machine learning algorithms in R.
@@ -56,9 +57,9 @@ To get one of the predefined learners, you need to access the `r ref("mlr_learne
 
 ```{r 02-basics-learners-004, R.options=list(max.print = 3)}
 library("mlr3learners")       # load recommended learners provided by mlr3learners package
-library("mlr3extralearners")  # load further less-well-supported learners
-library("mlr3proba")          # load further survival and density estimation learners
-library("mlr3cluster")        # load learners for clustering
+library("mlr3extralearners")  # this loads further less-well-supported learners
+library("mlr3proba")          # this loads some survival and density estimation learners
+library("mlr3cluster")        # this loads some learners for clustering
 
 mlr_learners
 ```

--- a/book/02-basics-learners.qmd
+++ b/book/02-basics-learners.qmd
@@ -27,9 +27,9 @@ The `r mlr3book::mlr_pkg("mlr3")` package ships with the following set of classi
 We deliberately keep this small to avoid unnecessary dependencies:
 
 * `r ref("mlr_learners_classif.featureless", text = "classif.featureless")`: Simple baseline classification learner.
-  The default is to predict the label that is most frequent in the training set every time. While this is not very useful by itself, it can be used as a "[fallback learner](fallback-learners)" to make predictions in case another, more sophisticated, learner failed for some reason.
+  The default is to always predict the label that is most frequent in the training set. While this is not very useful by itself, it can be used as a "[fallback learner](fallback-learners)" to make predictions in case another, more sophisticated, learner failed for some reason.
 * `r ref("mlr_learners_regr.featureless", text = "regr.featureless")`: Simple baseline regression learner.
-  The default is to predict the mean of the target in training set every time. Similar to `r ref("mlr_learners_classif.featureless")`, it makes for a good "[fallback learner](fallback-learners)"
+  The default is to always predict the mean of the target in training set. Similar to `r ref("mlr_learners_classif.featureless")`, it makes for a good "[fallback learner](fallback-learners)"
 * `r ref("mlr_learners_classif.rpart", text = "classif.rpart")`: Single classification tree from package `r mlr3book::cran_pkg("rpart")`.
 * `r ref("mlr_learners_regr.rpart", text = "regr.rpart")`: Single regression tree from package `r mlr3book::cran_pkg("rpart")`.
 
@@ -37,7 +37,7 @@ This set of baseline learners is usually insufficient for a real data analysis.
 Thus, we have cherry-picked implementations of the most popular machine learning method and collected them in the `r mlr3book::mlr_pkg("mlr3learners")` package:
 
 * Linear (`r ref("mlr_learners_regr.lm", text = "regr.lm")`) and logistic (`r ref("mlr_learners_classif.log_reg", text = "classif.log_reg")`) regression
-* Penalized Generalized Linear Models (regression: `r ref("mlr_learners_regr.glmnet", text = "regr.glmnet")`, `r ref("mlr_learners_regr.cv_glmnet", text = "regr.cv_glmnet")`; classification: `r ref("mlr_learners_classif.glmnet", text = "classif.glmnet")`, `ref("mlr_learners_classif.cv_glmnet", text = "classif.cv_glmnet")`)
+* Penalized Generalized Linear Models (`r ref("mlr_learners_regr.glmnet", text = "regr.glmnet")`, `r ref("mlr_learners_classif.glmnet", text = "classif.glmnet")`), possibly with built-in optimization of the penalization parameter (`r ref("mlr_learners_regr.cv_glmnet", text = "regr.cv_glmnet")`, `r ref("mlr_learners_classif.cv_glmnet", text = "classif.cv_glmnet")`)
 * (Kernelized) $k$-Nearest Neighbors regression (`r ref("mlr_learners_regr.kknn", text = "regr.kknn")`) and classification (`r ref("mlr_learners_classif.kknn", text = "classif.kknn")`).
 * Kriging / Gaussian Process Regression (`r ref("mlr_learners_regr.km", text = "regr.km")`)
 * Linear (`r ref("mlr_learners_classif.lda", text = "classif.lda")`) and Quadratic (`r ref("mlr_learners_classif.qda", text = "classif.qda")`) Discriminant Analysis

--- a/book/02-basics-learners.qmd
+++ b/book/02-basics-learners.qmd
@@ -10,8 +10,6 @@ They consist of methods to train and predict a model for a `r ref("Task")` and p
 
 The base class of each learner is `r ref("Learner")`, specialized for regression as `r ref("LearnerRegr")` and for classification as `r ref("LearnerClassif")`.
 Other types of learners, provided by extension packages, also inherit from the `r ref("Learner")` base class, e.g. `r ref("mlr3proba::LearnerSurv")` or `r ref("mlr3cluster::LearnerClust")`.
-In contrast to `r ref("Task")`s, the creation of a custom Learner is usually not required and a more advanced topic.
-Hence, we refer the reader to @sec-extending-learners and proceed with an overview of the interface of already implemented learners.
 
 All Learners work in a two-stage procedure:
 

--- a/book/02-basics-learners.qmd
+++ b/book/02-basics-learners.qmd
@@ -67,7 +67,6 @@ To obtain an object from the dictionary, use the `r ref("lrn()")` function.
 
 ```{r 02-basics-learners-004-2}
 learner = lrn("classif.rpart")
-learner
 ```
 
 Alternatively, the `mlr_learners$get()` function can be used, for which `r ref("lrn()")` is a shortcut.
@@ -83,14 +82,12 @@ Each learner provides the following meta-information:
   A complete list of these is available in the [mlr3 reference](https://mlr3.mlr-org.com/reference/mlr_reflections.html#examples).
 * `$predict_types`: possible prediction types. For example, a classification learner can predict labels ("response") or probabilities ("prob"). For a complete list of possible predict types see the [mlr3 reference](https://mlr3.mlr-org.com/reference/mlr_reflections.html#examples).
 
-You can retrieve a specific learner using its ID:
-
-```{r 02-basics-learners-005}
-learner = lrn("classif.rpart")
+This information can be queried through these slots, or seen at a glance from the printer:
+```{r 02-basics-learners-004-3}
 print(learner)
 ```
 
-Each learner has hyperparameters that control its behavior, for example the minimum number of samples in the leaf of a decision tree, or whether to provide verbose output durning training.
+Furthermore, each learner has hyperparameters that control its behavior, for example the minimum number of samples in the leaf of a decision tree, or whether to provide verbose output durning training.
 Setting hyperparameters to values appropriate for a given machine learning task is crucial.
 The field `param_set` stores a description of the hyperparameters the learner has, their ranges, defaults, and current values:
 

--- a/book/02-basics-learners.qmd
+++ b/book/02-basics-learners.qmd
@@ -54,10 +54,6 @@ More machine learning methods and alternative implementations are collected in t
 A full list of available learners across all `r mlr3book::mlr_pkg("mlr3")` packages is provided in [this interactive list](https://mlr3extralearners.mlr-org.com/articles/learners/list_learners.html) and via `mlr3extralearners::list_mlr3learners()`.
 :::
 
-```{r 02-basics-learners-003, }
-head(mlr3extralearners::list_mlr3learners()) # show first six learners
-```
-
 :::{.callout-note}
 The full list of learners uses a large number of extra packages, which sometimes break.
 We check the status of each learner's integration automatically, the latest build status of all learners is shown [here](https://mlr3extralearners.mlr-org.com/articles/learners/test_overview.html).
@@ -65,9 +61,12 @@ We check the status of each learner's integration automatically, the latest buil
 
 To get one of the predefined learners, you need to access the `r ref("mlr_learners")` `r ref("Dictionary")` which, similar to `r ref("mlr_tasks")`, is automatically populated with more learners by extension packages.
 
-```{r 02-basics-learners-004}
-# load most`r mlr3book::mlr_pkg("mlr3")`packages to populate the dictionary
-library("mlr3verse")
+```{r 02-basics-learners-004, R.options=list(max.print = 3)}
+library("mlr3learners")       # load recommended learners provided by mlr3learners package
+library("mlr3extralearners")  # load further less-well-supported learners
+library("mlr3proba")          # load further survival and density estimation learners
+library("mlr3cluster")        # load learners for clustering
+
 mlr_learners
 ```
 

--- a/book/02-basics-learners.qmd
+++ b/book/02-basics-learners.qmd
@@ -70,7 +70,14 @@ library("mlr3cluster")        # load learners for clustering
 mlr_learners
 ```
 
-To obtain an object from the dictionary you can also use the shortcut function `"lrn()"` or the generic `mlr_learners$get()` method, e.g. `lrn("classif.rpart")`.
+To obtain an object from the dictionary, use the `r ref("lrn()")` function.
+
+```{r 02-basics-learners-004-2}
+learner = lrn("classif.rpart")
+learner
+```
+
+Alternatively, the `mlr_learners$get()` function can be used, for which `r ref("lrn()")` is a shortcut.
 
 ## Learner API
 

--- a/book/02-basics-learners.qmd
+++ b/book/02-basics-learners.qmd
@@ -54,11 +54,6 @@ More machine learning methods and alternative implementations are collected in t
 A full list of available learners across all `r mlr3book::mlr_pkg("mlr3")` packages is provided in [this interactive list](https://mlr3extralearners.mlr-org.com/articles/learners/list_learners.html) and via `mlr3extralearners::list_mlr3learners()`.
 :::
 
-:::{.callout-note}
-The full list of learners uses a large number of extra packages, which sometimes break.
-We check the status of each learner's integration automatically, the latest build status of all learners is shown [here](https://mlr3extralearners.mlr-org.com/articles/learners/test_overview.html).
-:::
-
 To get one of the predefined learners, you need to access the `r ref("mlr_learners")` `r ref("Dictionary")` which, similar to `r ref("mlr_tasks")`, is automatically populated with more learners by extension packages.
 
 ```{r 02-basics-learners-004, R.options=list(max.print = 3)}

--- a/book/02-basics-learners.qmd
+++ b/book/02-basics-learners.qmd
@@ -96,26 +96,17 @@ learner$param_set
 ```
 
 The set of current hyperparameter values is stored in the `values` field of the `param_set` field.
-You can change the current hyperparameter values by assigning a named list to this field:
+You can access and change the current hyperparameter values by accessing this field, it is a named list:
 
 ```{r 02-basics-learners-007}
-learner$param_set$values = list(cp = 0.01, xval = 0)
-learner
+learner$param_set$values
+learner$param_set$values$cp = 0.01
+learner$param_set$values
 ```
 
-:::{.callout-caution}
-This operation overwrites all previously set parameters.
+:::{.callout-tip}
+It is possible to assign all hyperparameters in one go by assigning a named list to `$values`: `learner$param_set$values = list(cp = 0.01, xval = 0)`. However, be aware that this operation also removes all previously set hyperparameters.
 :::
-
-You can also get the current set of hyperparameter values, modify it, and write it back to the learner:
-
-```{r 02-basics-learners-008}
-pv = learner$param_set$values
-pv$cp = 0.02
-learner$param_set$values = pv
-```
-
-This sets `cp` to `0.02` but keeps any other values that were set previously.
 
 The `r ref("lrn()")` function also accepts additional arguments to update hyperparameters or set fields of the learner in one go:
 
@@ -127,30 +118,3 @@ learner$param_set$values
 
 More on this is discussed in the section on [Hyperparameter Tuning](https://mlr3book.mlr-org.com/optimization.html#tuning).
 
-### Thresholding
-
-Models trained on binary classification tasks that predict the probability for the positive class usually use a simple rule to determine the predicted class label: if the probability is more than 50%, predict the positive label, otherwise predict the negative label.
-In some cases you may want to adjust this threshold, for example if the classes are very unbalanced (i.e. one is much more prevalent than the other).
-
-In the example below, we change the threshold to 0.2, which improves the True Positive Rate (TPR).
-Note that while the new threshold classifies more observations from the positive class correctly, the True Negative Rate (TNR) decreases.
-Depending on the application, this may or may not be desired.
-
-```{r 02-basics-learners-010}
-data("Sonar", package = "mlbench")
-task = as_task_classif(Sonar, target = "Class", positive = "M")
-learner = lrn("classif.rpart", predict_type = "prob")
-pred = learner$train(task)$predict(task)
-
-measures = msrs(c("classif.tpr", "classif.tnr")) # use msrs() to get a list of multiple measures
-pred$confusion
-pred$score(measures)
-
-pred$set_threshold(0.2)
-pred$confusion
-pred$score(measures)
-```
-
-:::{.callout-tip}
-Thresholds can be tuned automatically with the `r mlr3book::mlr_pkg("mlr3pipelines")` package, i.e. using `r ref("mlr_pipeops_tunethreshold", text = "PipeOpTuneThreshold")`.
-:::

--- a/book/02-basics-learners.qmd
+++ b/book/02-basics-learners.qmd
@@ -37,14 +37,14 @@ This set of baseline learners is usually insufficient for a real data analysis.
 Thus, we have cherry-picked implementations of the most popular machine learning method and collected them in the `r mlr3book::mlr_pkg("mlr3learners")` package:
 
 * Linear (`r ref("mlr_learners_regr.lm", text = "regr.lm")`) and logistic (`r ref("mlr_learners_classif.log_reg", text = "classif.log_reg")`) regression
-* Penalized Generalized Linear Models (regression: `r ref("mlr_learners_regr.glmnet", text = "regr.glmnet")`, `r ref("mlr_learners_regr.cv_glmnet", text = "regr.cv_glmnet")`; classification: `r ref("mlr_learners_classif.glmnet", text = "classif.glmnet")`, `ref("mlr_learners_classif.cv_glmnet", text = "classif.cv_glmnet")`; survival: `r ref("mlr_learners_surv.glmnet", text = "surv.glmnet")`, `ref("mlr_learners_surv.cv_glmnet", text = "surv.cv_glmnet")`)
+* Penalized Generalized Linear Models (regression: `r ref("mlr_learners_regr.glmnet", text = "regr.glmnet")`, `r ref("mlr_learners_regr.cv_glmnet", text = "regr.cv_glmnet")`; classification: `r ref("mlr_learners_classif.glmnet", text = "classif.glmnet")`, `ref("mlr_learners_classif.cv_glmnet", text = "classif.cv_glmnet")`)
 * (Kernelized) $k$-Nearest Neighbors regression (`r ref("mlr_learners_regr.kknn", text = "regr.kknn")`) and classification (`r ref("mlr_learners_classif.kknn", text = "classif.kknn")`).
 * Kriging / Gaussian Process Regression (`r ref("mlr_learners_regr.km", text = "regr.km")`)
 * Linear (`r ref("mlr_learners_classif.lda", text = "classif.lda")`) and Quadratic (`r ref("mlr_learners_classif.qda", text = "classif.qda")`) Discriminant Analysis
 * Naive Bayes Classification (`r ref("mlr_learners_classif.naive_bayes", text = "classif.naive_bayes")`)
 * Support-Vector machines (`r ref("mlr_learners_regr.svm", text = "regr.svm")`, `r ref("mlr_learners_classif.svm", text = "classif.svm")`)
-* Gradient Boosting (`r ref("mlr_learners_regr.xgboost", text = "regr.xgboost")`, `r ref("mlr_learners_classif.xgboost", text = "classif.xgboost")`, `r ref("mlr_learners_surv.xgboost", text = "surv.xgboost")`)
-* Random Forests for regression, classification and survival (`r ref("mlr_learners_regr.ranger", text = "regr.ranger")`, `r ref("mlr_learners_classif.ranger", text = "classif.ranger")`, `r ref("mlr_learners_surv.ranger", text = "surv.ranger")`)
+* Gradient Boosting (`r ref("mlr_learners_regr.xgboost", text = "regr.xgboost")`, `r ref("mlr_learners_classif.xgboost", text = "classif.xgboost")`)
+* Random Forests for regression and classification (`r ref("mlr_learners_regr.ranger", text = "regr.ranger")`, `r ref("mlr_learners_classif.ranger", text = "classif.ranger")`)
 
 More machine learning methods and alternative implementations are collected in the [mlr3extralearners repository](https://github.com/mlr-org/mlr3extralearners/).
 

--- a/book/02-basics-learners.qmd
+++ b/book/02-basics-learners.qmd
@@ -3,7 +3,6 @@
 ```{r 02-basics-learners-001, include = F}
 library(mlr3)
 library(mlr3book)
-library("mlr3learners")
 ```
 
 Objects of class `r ref("Learner")` provide a unified interface to many popular machine learning algorithms in R.
@@ -41,7 +40,7 @@ Thus, we have cherry-picked implementations of the most popular machine learning
 * Penalized Generalized Linear Models (regression: `r ref("mlr_learners_regr.glmnet", text = "regr.glmnet")`, `r ref("mlr_learners_regr.cv_glmnet", text = "regr.cv_glmnet")`; classification: `r ref("mlr_learners_classif.glmnet", text = "classif.glmnet")`, `ref("mlr_learners_classif.cv_glmnet", text = "classif.cv_glmnet")`; survival: `r ref("mlr_learners_surv.glmnet", text = "surv.glmnet")`, `ref("mlr_learners_surv.cv_glmnet", text = "surv.cv_glmnet")`)
 * (Kernelized) $k$-Nearest Neighbors regression (`r ref("mlr_learners_regr.kknn", text = "regr.kknn")`) and classification (`r ref("mlr_learners_classif.kknn", text = "classif.kknn")`).
 * Kriging / Gaussian Process Regression (`r ref("mlr_learners_regr.km", text = "regr.km")`)
-* Linear (`r ref("mlr_learners_regr.lda", text = "regr.lda")`, `r ref("mlr_learners_classif.lda", text = "classif.lda")`) and Quadratic (`r ref("mlr_learners_regr.qda", text = "regr.qda")`, `r ref("mlr_learners_classif.qda", text = "classif.qda")`) Discriminant Analysis
+* Linear (`r ref("mlr_learners_classif.lda", text = "classif.lda")`) and Quadratic (`r ref("mlr_learners_classif.qda", text = "classif.qda")`) Discriminant Analysis
 * Naive Bayes Classification (`r ref("mlr_learners_classif.naive_bayes", text = "classif.naive_bayes")`)
 * Support-Vector machines (`r ref("mlr_learners_regr.svm", text = "regr.svm")`, `r ref("mlr_learners_classif.svm", text = "classif.svm")`)
 * Gradient Boosting (`r ref("mlr_learners_regr.xgboost", text = "regr.xgboost")`, `r ref("mlr_learners_classif.xgboost", text = "classif.xgboost")`, `r ref("mlr_learners_surv.xgboost", text = "surv.xgboost")`)

--- a/book/02-basics-learners.qmd
+++ b/book/02-basics-learners.qmd
@@ -28,25 +28,25 @@ knitr::include_graphics("images/learner.svg")
 The `r mlr3book::mlr_pkg("mlr3")` package ships with the following set of classification and regression learners.
 We deliberately keep this small to avoid unnecessary dependencies:
 
-* `r ref("mlr_learners_classif.featureless")`: Simple baseline classification learner.
+* `r ref("mlr_learners_classif.featureless", text = "classif.featureless")`: Simple baseline classification learner.
   The default is to predict the label that is most frequent in the training set every time. While this is not very useful by itself, it can be used as a "[fallback learner](fallback-learners)" to make predictions in case another, more sophisticated, learner failed for some reason.
-* `r ref("mlr_learners_regr.featureless")`: Simple baseline regression learner.
+* `r ref("mlr_learners_regr.featureless", text = "regr.featureless")`: Simple baseline regression learner.
   The default is to predict the mean of the target in training set every time. Similar to `r ref("mlr_learners_classif.featureless")`, it makes for a good "[fallback learner](fallback-learners)"
-* `r ref("mlr_learners_classif.rpart")`: Single classification tree from package `r mlr3book::cran_pkg("rpart")`.
-* `r ref("mlr_learners_regr.rpart")`: Single regression tree from package `r mlr3book::cran_pkg("rpart")`.
+* `r ref("mlr_learners_classif.rpart", text = "classif.rpart")`: Single classification tree from package `r mlr3book::cran_pkg("rpart")`.
+* `r ref("mlr_learners_regr.rpart", text = "regr.rpart")`: Single regression tree from package `r mlr3book::cran_pkg("rpart")`.
 
 This set of baseline learners is usually insufficient for a real data analysis.
 Thus, we have cherry-picked implementations of the most popular machine learning method and collected them in the `r mlr3book::mlr_pkg("mlr3learners")` package:
 
-* Linear and logistic regression
-* Penalized Generalized Linear Models
-* $k$-Nearest Neighbors regression and classification
-* Kriging
-* Linear and Quadratic Discriminant Analysis
-* Naive Bayes
-* Support-Vector machines
-* Gradient Boosting
-* Random Forests for regression, classification and survival
+* Linear (`r ref("mlr_learners_regr.lm", text = "regr.lm")`) and logistic (`r ref("mlr_learners_classif.log_reg", text = "classif.log_reg")`) regression
+* Penalized Generalized Linear Models (regression: `r ref("mlr_learners_regr.glmnet", text = "regr.glmnet")`, `r ref("mlr_learners_regr.cv_glmnet", text = "regr.cv_glmnet")`; classification: `r ref("mlr_learners_classif.glmnet", text = "classif.glmnet")`, `ref("mlr_learners_classif.cv_glmnet", text = "classif.cv_glmnet")`; survival: `r ref("mlr_learners_surv.glmnet", text = "surv.glmnet")`, `ref("mlr_learners_surv.cv_glmnet", text = "surv.cv_glmnet")`)
+* (Kernelized) $k$-Nearest Neighbors regression (`r ref("mlr_learners_regr.kknn", text = "regr.kknn")`) and classification (`r ref("mlr_learners_classif.kknn", text = "classif.kknn")`).
+* Kriging / Gaussian Process Regression (`r ref("mlr_learners_regr.km", text = "regr.km")`)
+* Linear (`r ref("mlr_learners_regr.lda", text = "regr.lda")`, `r ref("mlr_learners_classif.lda", text = "classif.lda")`) and Quadratic (`r ref("mlr_learners_regr.qda", text = "regr.qda")`, `r ref("mlr_learners_classif.qda", text = "classif.qda")`) Discriminant Analysis
+* Naive Bayes Classification (`r ref("mlr_learners_classif.naive_bayes", text = "classif.naive_bayes")`)
+* Support-Vector machines (`r ref("mlr_learners_regr.svm", text = "regr.svm")`, `r ref("mlr_learners_classif.svm", text = "classif.svm")`)
+* Gradient Boosting (`r ref("mlr_learners_regr.xgboost", text = "regr.xgboost")`, `r ref("mlr_learners_classif.xgboost", text = "classif.xgboost")`, `r ref("mlr_learners_surv.xgboost", text = "surv.xgboost")`)
+* Random Forests for regression, classification and survival (`r ref("mlr_learners_regr.ranger", text = "regr.ranger")`, `r ref("mlr_learners_classif.ranger", text = "classif.ranger")`, `r ref("mlr_learners_surv.ranger", text = "surv.ranger")`)
 
 More machine learning methods and alternative implementations are collected in the [mlr3extralearners repository](https://github.com/mlr-org/mlr3extralearners/).
 

--- a/book/02-basics-learners.qmd
+++ b/book/02-basics-learners.qmd
@@ -28,10 +28,10 @@ knitr::include_graphics("images/learner.svg")
 The `r mlr3book::mlr_pkg("mlr3")` package ships with the following set of classification and regression learners.
 We deliberately keep this small to avoid unnecessary dependencies:
 
-* `r ref("mlr_learners_classif.featureless")`: Simple baseline classification learner (inheriting from `r ref("LearnerClassif")`).
-  The default is to predict the label that is most frequent in the training set every time.
-* `r ref("mlr_learners_regr.featureless")`: Simple baseline regression learner (inheriting from `r ref("LearnerRegr")`).
-  The default is to predict the mean of the target in training set every time.
+* `r ref("mlr_learners_classif.featureless")`: Simple baseline classification learner.
+  The default is to predict the label that is most frequent in the training set every time. While this is not very useful by itself, it can be used as a "[fallback learner](fallback-learners)" to make predictions in case another, more sophisticated, learner failed for some reason.
+* `r ref("mlr_learners_regr.featureless")`: Simple baseline regression learner.
+  The default is to predict the mean of the target in training set every time. Similar to `r ref("mlr_learners_classif.featureless")`, it makes for a good "[fallback learner](fallback-learners)"
 * `r ref("mlr_learners_classif.rpart")`: Single classification tree from package `r mlr3book::cran_pkg("rpart")`.
 * `r ref("mlr_learners_regr.rpart")`: Single regression tree from package `r mlr3book::cran_pkg("rpart")`.
 

--- a/book/02-basics-learners.qmd
+++ b/book/02-basics-learners.qmd
@@ -76,12 +76,12 @@ Alternatively, the `mlr_learners$get()` function can be used, for which `r ref("
 
 Each learner provides the following meta-information:
 
-* `feature_types`: the type of features the learner can deal with.
-* `packages`: the packages required to train a model with this learner and make predictions.
-* `properties`: additional properties and capabilities.
+* `$feature_types`: the type of features the learner can deal with.
+* `$packages`: the packages required to train a model with this learner and make predictions.
+* `$properties`: additional properties and capabilities.
   For example, a learner has the property "missings" if it is able to handle missing feature values, and "importance" if it computes and allows to extract data on the relative importance of the features.
   A complete list of these is available in the [mlr3 reference](https://mlr3.mlr-org.com/reference/mlr_reflections.html#examples).
-* `predict_types`: possible prediction types. For example, a classification learner can predict labels ("response") or probabilities ("prob"). For a complete list of possible predict types see the [mlr3 reference](https://mlr3.mlr-org.com/reference/mlr_reflections.html#examples).
+* `$predict_types`: possible prediction types. For example, a classification learner can predict labels ("response") or probabilities ("prob"). For a complete list of possible predict types see the [mlr3 reference](https://mlr3.mlr-org.com/reference/mlr_reflections.html#examples).
 
 You can retrieve a specific learner using its ID:
 


### PR DESCRIPTION
Can be reviewed now. Changes:
* not linking to "extending learners" section any more, as requested by Bernd
* not mentioning class hierarchy of featureless learners any more; instead explain why they are useful (backup learner)
* mention names / references of learners listed for mlr3learners
* remove extralink "learners which sometimes break" link, as requested by Bernd
* loading packages explicitly and explaining what learners they contain instead of loading mlr3verse package
* prepend slot names with `$`
* hyperparameter assignments explained as `learner$param_set$values$<name> = <value>`  first, alternatives given later
* thresholding moved away to "Train, Predict, Assess Performance" chapter