### PR TITLE
fix: Typos, remove wiki link

### DIFF
--- a/book/basics.qmd
+++ b/book/basics.qmd
@@ -288,7 +288,7 @@ The previously-constructed `task_penguins_small` task, for example, has the foll
 task_penguins_small$col_roles
 ```
 
-Columns can have have multiple roles. It is also possible for a column to have no role at all, in which case they are ignored. This is, in fact, how `$select()` and `$filter()` operate: They unassign the `"feature"` (for columns) or `"use"` (for rows) role without modifying the data which is stored in an immutable backend:
+Columns can have multiple roles. It is also possible for a column to have no role at all, in which case they are ignored. This is, in fact, how `$select()` and `$filter()` operate: They unassign the `"feature"` (for columns) or `"use"` (for rows) role without modifying the data which is stored in an immutable backend:
 
 ```{r basics-022}
 task_penguins_small$backend

--- a/book/intro.qmd
+++ b/book/intro.qmd
@@ -3,7 +3,7 @@
 {{< include _setup.qmd >}}
 
 
-The `r mlr_pkg("mlr3")` [@mlr3] package and [ecosystem](https://github.com/mlr-org/mlr3/wiki/Extension-Packages) provide a generic, object-oriented, and extensible framework for [classification](#tasks), [regression](#tasks), [survival analysis](#survival), and other machine learning tasks for the R language [@R].
+The `r mlr_pkg("mlr3")` [@mlr3] package and ecosystem provide a generic, object-oriented, and extensible framework for [classification](#tasks), [regression](#tasks), [survival analysis](#survival), and other machine learning tasks for the R language [@R].
 This unified interface provides functionality to extend and combine existing [learners](#learners), intelligently select and tune the most appropriate technique for a [task](#tasks), and perform large-scale comparisons that enable meta-learning.
 Examples of this advanced functionality include [hyperparameter tuning](#tuning) and [feature selection](#fs).
 [Parallelization](#parallelization) of many operations is natively supported.
@@ -42,8 +42,8 @@ We follow these general design principles in the `r mlr_pkg("mlr3")` package and
 
 * **Backend over frontend**.
   Most packages of the `r mlr_pkg("mlr3")` ecosystem focus on processing and transforming data, applying machine learning algorithms, and computing results.
-  Our core packages do not provide a graphical user interfaces (GUIs) whose dependencies would make an installation on a computing server unnecassary tedious; visualizations of data and results are provided in extra packages like `r mlr_pkg("mlr3viz")`. `r cran_pkg("mlr3shiny")` provides an interface for some basic machine learning tasks using the `r cran_pkg("shiny")` package.
-* **Object oriientation**. Embrace `r cran_pkg("R6")` for a clean, object-oriented design, object state-changes, and reference semantics.
+  Our core packages do not provide a graphical user interfaces (GUIs) whose dependencies would make an installation on a computing server unnecessarily tedious; visualizations of data and results are provided in extra packages like `r mlr_pkg("mlr3viz")`. `r cran_pkg("mlr3shiny")` provides an interface for some basic machine learning tasks using the `r cran_pkg("shiny")` package.
+* **Object orientation**. Embrace `r cran_pkg("R6")` for a clean, object-oriented design, object state-changes, and reference semantics.
 * **Tabular data**. Embrace `r cran_pkg("data.table")` for fast and convenient computations on tabular data.
 * **Unify container and result classes** as much as possible and provide result data in `data.table`s.
     This considerably simplifies the API and allows easy selection and "split-apply-combine" (aggregation) operations.


### PR DESCRIPTION
Small typos I would have fixed on `main` but it's branch-protected 🤷‍♂️