### PR TITLE
Revert "Remove quickstart section"

### DIFF
--- a/book/index.qmd
+++ b/book/index.qmd
@@ -1,7 +1,31 @@
-# The mlr3 book {-}
+# Quickstart {-}
 
 {{< include _setup.qmd >}}
 
-:::{.callout-note}
-We'll add an introductory paragraph here
+```{r index-001, eval = FALSE}
+install.packages("mlr3")
+```
+
+As a 30-second introductory example, we will train a decision tree model on the first 120 rows of iris data set and make predictions on the final 30, measuring the accuracy of the trained model.
+
+```{r index-002}
+library("mlr3")
+task = tsk("iris")
+learner = lrn("classif.rpart")
+
+# train a model of this learner for a subset of the task
+learner$train(task, row_ids = 1:120)
+# this is what the decision tree looks like
+learner$model
+
+predictions = learner$predict(task, row_ids = 121:150)
+predictions
+# accuracy of our model on the test set of the final 30 rows
+predictions$score(msr("classif.acc"))
+```
+
+:::{.callout-tip}
+A collection of use cases and examples can be found in the [mlr3gallery](https://mlr-org.com/gallery) on our [website](https://mlr-org.com).
+
+We highly recommend to take a look at our `r mlr3book::mlr_pkg("cheatsheets")` while diving deeper into `r mlr3book::mlr_pkg("mlr3")`.
 :::


### PR DESCRIPTION
Reverts mlr-org/mlr3book#405

The current placeholder is definitely not better than the quickstart we had before.
Sorry for the hard override but I think it's valid to do so in this specific case.

A PR or actual content replacing the quickstart section would be great!