### PR TITLE
Update output PDF path in build-book.yml

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: mlr3book
-          path: book/_book/mlr3book.pdf
+          path: book/_book/Flexible-and-Robust-Machine-Learning-Using-mlr3-in-R.pdf
           retention-days: 1
 
       - name: Deploy


### PR DESCRIPTION
Previous file name was `mlr3book.pdf` but recently the names was changed to reflect the title of the book.