### PR TITLE
Remove # from callout box text

### DIFF
--- a/book/_complex.qmd
+++ b/book/_complex.qmd
@@ -1,3 +1,3 @@
 :::{.callout-important appearance="simple"}
-# This section of the book might be complex for some readers.
+This section of the book might be complex for some readers.
 :::

--- a/book/_optional.qmd
+++ b/book/_optional.qmd
@@ -1,3 +1,3 @@
 :::{.callout-note appearance="simple"}
-# Some readers may want to skip this section of the book.
+Some readers may want to skip this section of the book.
 :::


### PR DESCRIPTION
The `#` led to the box text accidentally becoming first-level headings in the PDF version.

![Screenshot 2023-02-16 at 17 13 27](https://user-images.githubusercontent.com/1613346/219423679-d00b3ef8-7470-404a-998a-5c82628ef9be.jpg)
