### PR TITLE
Modifying `performance-043` chunk.

### DIFF
--- a/book/performance.qmd
+++ b/book/performance.qmd
@@ -862,12 +862,12 @@ Here, the predictions of individual resampling iterations are merged prior to ca
 #| layout-ncol: 2
 rr = resample(
   task = tsk("spam"),
-  learner = lrn("classif.rpart"),
+  learner = lrn("classif.rpart", predict_type="prob"),
   resampling = rsmp("cv", folds = 10)
 )
 
-autoplot(rr1, type = "roc")
-autoplot(rr1, type = "prc")
+autoplot(rr, type = "roc")
+autoplot(rr, type = "prc")
 ```
 
 We can also visualize a `r ref("BenchmarkResult")` to compare multiple learners on the same `r ref("Task")`:


### PR DESCRIPTION
To run the `performance-043` chunk properly, the `predict_type="prob"` argument is needed. Moreover, `rr1` is modified as `rr`.