### PR TITLE
fix: replace kknn with lda

### DIFF
--- a/book/preface.qmd
+++ b/book/preface.qmd
@@ -55,7 +55,7 @@ tuned_rf = pipeline_robustify(NULL, tuned_rf, TRUE) %>>%
     po("learner", tuned_rf)
 stack_lrn = ppl(
     "stacking",
-    base_learners = lrns(c("classif.rpart", "classif.kknn")),
+    base_learners = lrns(c("classif.rpart", "classif.lda")),
     lrn("classif.log_reg"))
 stack_lrn = pipeline_robustify(NULL, stack_lrn, TRUE) %>>%
     po("learner", stack_lrn)


### PR DESCRIPTION
The kknn broke the CI.
When installing kknn from source in the CI, the following error was thrown:

Error in dyn.load(file, DLLpath = DLLpath, ...) :
  unable to load shared object '/home/runner/work/_temp/Library/.renv/1/igraph/libs/igraph.so':
  libglpk.so.40: cannot open shared object file: No such file or directory