### PR TITLE
Fix author abbreviations for authors with more than one first name

### DIFF
--- a/book/_utils.qmd
+++ b/book/_utils.qmd
@@ -26,7 +26,7 @@ citeas = function(chaptitle) {
   authors = unlist(strsplit(data.table::fread("chap_auths.csv")[Title == chaptitle, Authors], ", "))
   if (is.null(authors)) stop(sprintf("Chapter %s not found", chaptitle))
   authors = paste0(vapply(strsplit(authors, " "), function(.x) {
-    paste(.x[[2]], substr(.x[[1]], 1, 1))
+    paste(.x[[length(.x)]], paste(substr(.x[seq(1, length(.x) - 1)], 1, 1), collapse = ""))
   }, character(1)), collapse = ", ")
   chaphtml = paste0(paste0(tolower(strsplit(chaptitle, " ")[[1]]), collapse = "-"), ".html")
   sprintf("## Citation


### PR DESCRIPTION
My name was abbreviated with "N M" because of the middle initial.