### PR TITLE
fix: consistent use of abbreviations

### DIFF
--- a/book/advanced_tuning.qmd
+++ b/book/advanced_tuning.qmd
@@ -240,7 +240,7 @@ This means Hyperband will allocate increasingly more boosting iterations to well
 Increasing the number of boosting iterations increases the time to train a model but generally also the performance.
 It is therefore a suitable fidelity parameter.
 However, as already mentioned, Hyperband is not limited to machine learning algorithms that are trained iteratively.
-In the second example, we will tune a support vector machine and use the size of the training data as the fidelity parameter.
+In the second example, we will tune an SVM and use the size of the training data as the fidelity parameter.
 Some prior knowledge about pipelines (@sec-pipelines) is beneficial but not necessary to fully understand the examples.
 In the following, the terms fidelity and budget are often used interchangeably.
 
@@ -367,7 +367,7 @@ as.data.table(instance$archive)[,
 
 ### Example Support Vector Machine {#sec-hyperband-example-svm}
 
-In this example, we will optimize the hyperparameters of a support vector machine on the `sonar` dataset.
+In this example, we will optimize the hyperparameters of an SVM on the `sonar` dataset.
 We begin by constructing the learner and setting `type` to `"C-classification"`.
 
 ```{r optimization-070}
@@ -391,7 +391,7 @@ graph_learner = as_learner(
 )
 ```
 
-The graph learner subsamples and then fits a support vector machine on the data subset.
+The graph learner subsamples and then fits an SVM machine on the data subset.
 The parameter set of the graph learner is a combination of the parameter sets of the pipeline operator and learner.
 
 ```{r optimization-073}
@@ -402,7 +402,7 @@ Next, we create the search space.
 We have to prefix the hyperparameters with the id of the pipeline operators, because this reflects the way how they are represented in the parameter set of the graph learner.
 The `subsample.frac` is the fidelity parameter that must be tagged with `"budget"` in the search space.
 In the following, the dataset size is increased from 3.7% to 100%.
-For the other hyperparameters, we take the search space for support vector machines from @binder2020.
+For the other hyperparameters, we take the search space for SVMs from @binder2020.
 This search space usually work well for a wide range of datasets.
 
 ```{r optimization-074}
@@ -457,7 +457,7 @@ We can now start the tuning.
 tuner$optimize(instance)
 ```
 
-We observe that the best model is a support vector machine with a polynomial kernel.
+We observe that the best model is an SVM with a polynomial kernel.
 
 ```{r optimization-080}
 instance$result[, .(classif.ce, subsample.frac, svm.kernel)]

--- a/book/advanced_tuning.qmd
+++ b/book/advanced_tuning.qmd
@@ -45,7 +45,7 @@ instance = tune(
 )
 ```
 
-In the above example, we can see the tuning process breaks and we lose all information about the HPO process as the `instance` cannot be saved.
+In the above example, we can see the tuning process breaks and we lose all information about the hyperparameter optimization process as the `instance` cannot be saved.
 This is even worse in nested resampling or benchmarking, when errors could cause us to lose all progress across multiple configurations or even learners and tasks.
 
 `r index('Encapsulation')` (@sec-encapsulation) allows errors to be isolated and handled, without disrupting the tuning process.
@@ -65,7 +65,7 @@ learner$timeout = c(train = 30, predict = 30)
 ```
 
 Now if either an error occurs, or the model timeout threshold is reached, then instead of breaking, the learner will simply not make predictions when errors are found.
-Unfortunately, if predictions are not made, then our HPO experiment will still fail as for any resampling iteration with errors, the result will be `NA`, and so are unable to aggregate results across resampling iterations.
+Unfortunately, if predictions are not made, then our hyperparameter optimization experiment will still fail as for any resampling iteration with errors, the result will be `NA`, and so are unable to aggregate results across resampling iterations.
 Therefore it is essential to also select a fallback learner (@sec-fallback), which is a learner that will be fitted if the learner of interest fails.
 A common approach is to use a featureless baseline, `classif/regr.featureless`.
 Below we set `regr.featureless`, which always predicts the mean `response`, by passing this learner to the `$fallback` field.
@@ -136,9 +136,9 @@ Then, A pareto-dominates B if: 1) $CE_A \leq CE_B$ and $CP_A < CP_B$ or; 2) $CE_
 All configurations that are not Pareto-dominated by any other configuration are called `r index('Pareto-efficient')` and the set of all these configurations is the `r index("Pareto set", aside = TRUE)`.
 The metric values corresponding to these Pareto set are referred to as the `r index("Pareto front", aside = TRUE)`.
 
-The goal of multi-objective HPO is to approximate the Pareto front.
-We will now demonstrate multi-objective HPO by tuning a decision tree on the `sonar` task with respect to the classification error, as a measure of model performance, and the number of selected features, as a measure of model complexity (in a decision tree the number of selected features is straightforward to obtain by simply counting the number of unique splitting variables).
-Methodological details on multi-objective HPO can be found in @hpo_multi.
+The goal of multi-objective hyperparameter optimization is to approximate the Pareto front.
+We will now demonstrate multi-objective hyperparameter optimization by tuning a decision tree on the `sonar` task with respect to the classification error, as a measure of model performance, and the number of selected features, as a measure of model complexity (in a decision tree the number of selected features is straightforward to obtain by simply counting the number of unique splitting variables).
+Methodological details on multi-objective hyperparameter optimization can be found in @hpo_multi.
 
 We will tune `cp`, `minsplit`, and `maxdepth`:
 
@@ -227,13 +227,13 @@ Furthermore, it can also be quite difficult to compare multiple models over mult
 ## Multi-Fidelity Tuning via Hyperband {#sec-hyperband}
 <!-- TODO: RS NOT REVIEWED YET -->
 
-Increasingly large datasets and search spaces and costly to train models make hyperparameter optimization a time-consuming task.
-Recent HPO methods often also make use of evaluating a configuration at multiple fidelity levels.
+Increasingly large datasets and search spaces and costly to train models make HPO a time-consuming task.
+Recent hyperparameter optimization methods often also make use of evaluating a configuration at multiple fidelity levels.
 For example, a neural network can be trained for an increasing number of epochs, gradient boosting can be performed for an increasing number of boosting iterations and training data can always be subsampled to a smaller fraction of all available data.
-The general idea of *multi-fidelity* HPO is that the performance of a model obtained by using computationally cheap lower fidelity evaluation (few numbers of epochs or boosting iterations, only using a small sample of all available data for training) is predictive of the performance of the model obtained using computationally expensive full model evaluation and this concept can be leveraged to make HPO more efficient (e.g., only continuing to evaluate those configurations on higher fidelities that appear to be promising with respect to their performance).
+The general idea of *multi-fidelity* hyperparameter optimization is that the performance of a model obtained by using computationally cheap lower fidelity evaluation (few numbers of epochs or boosting iterations, only using a small sample of all available data for training) is predictive of the performance of the model obtained using computationally expensive full model evaluation and this concept can be leveraged to make HPO more efficient (e.g., only continuing to evaluate those configurations on higher fidelities that appear to be promising with respect to their performance).
 The fidelity parameter is part of the search space and controls the trade-off between the runtime and preciseness of the performance approximation.
 
-A popular multi-fidelity HPO algorithm is *Hyperband* [@li_2018].
+A popular multi-fidelity hyperparameter optimization algorithm is *Hyperband* [@li_2018].
 After having evaluated randomly sampled configurations on low fidelities, Hyperband iteratively allocates more resources to promising configurations and terminates low-performing ones.
 In the following example, we will optimize XGBoost and use the number of boosting iterations as the fidelity parameter.
 This means Hyperband will allocate increasingly more boosting iterations to well-performing hyperparameter configurations.
@@ -523,7 +523,7 @@ Often, using BO results in very good optimization performance, especially if the
 
 In the following, we will give a brief general introduction to black-box optimization making use of the `r bbotk`\index{bbotk} package.
 We then introduce the building blocks of BO algorithms and examine their interplay and interaction during the optimization process before we assemble these building blocks in a ready to use black-box optimizer, illustrating how BO can be performed within the mlr3 ecosystem making use of the `r mlr3mbo`\index{mlr3mbo} package.
-Readers who are primarily interested in how to utilize BO for hyperparameter optimization without delving deep into the underlying building blocks can directly proceed to @sec-bayesian-tuning.
+Readers who are primarily interested in how to utilize BO for HPO without delving deep into the underlying building blocks can directly proceed to @sec-bayesian-tuning.
 Detailed introductions to black-box optimization and BO are given in @hpo_practical, @hpo_automl and @garnett_2022.
 
 #### Black-Box Optimization {#sec-black-box-optimization}
@@ -1397,7 +1397,7 @@ The standard behavior of most BO algorithms is to sequentially propose a single 
 Still, users may want to use compute resources more efficiently via parallelization.
 `r mlr3mbo` offers two ways to do this:
 
-1. In the case of hyperparameter optimization, it is usually best to parallelize the evaluation of a model, i.e., the resampling.
+1. In the case of HPO, it is usually best to parallelize the evaluation of a model, i.e., the resampling.
 This is straightforward as explained in @sec-parallel-resample.
 2. If the actual proposal mechanism of a BO algorithm should be parallelized in the sense that the loop function proposes a *batch* of candidates\index{batch proposal}[Batch Proposal]{.aside} that should be evaluated synchronously in the next iteration, the evaluation of the objective function itself must be parallelized.
 Moreover, the `r ref("loop_function")` must be able to support batch proposals of candidates, e.g., `bayesopt_mpcl()` (`r ref("mlr_loop_functions_mpcl")`) and `bayesopt_parego()` (`r ref("mlr_loop_functions_parego")`) support this by setting the `q` argument to a value larger than `1`.

--- a/book/advanced_tuning.qmd
+++ b/book/advanced_tuning.qmd
@@ -24,7 +24,7 @@ In particular, we will consider how to enable features that prevent fatal errors
 
 Error handling is discussed in detail in @sec-error-handling, however it is very important in the context of tuning so here we will just practically demonstrate how to make use of encapsulation and fallback learners and explain why they are essential during HPO.
 
-Even in simple ML problems, there is a lot of potential for things to go wrong.
+Even in simple machine learning problems, there is a lot of potential for things to go wrong.
 For example when learners do not converge, run out of memory, or terminate with an error due to issues in the underlying data or bugs in the code.
 As a common example, learners can fail if there are factor levels present in the test data that were not in the training data, models fail in this case as there have been no weights/coefficients trained for these new factor levels:
 
@@ -497,7 +497,7 @@ ggplot(data, aes(x = subsample.frac, y = classif.ce, group = i)) +
 
 ## Bayesian Optimization {#sec-bayesian-optimization}
 
-In hyperparameter optimization (HPO, see @sec-optimization), we configure a learner with a hyperparameter configuration and evaluate the learner on a given task via a resampling technique to estimate its generalization performance with the goal to find the optimal hyperparameter configuration.
+In HPO (@sec-optimization), we configure a learner with a hyperparameter configuration and evaluate the learner on a given task via a resampling technique to estimate its generalization performance with the goal to find the optimal hyperparameter configuration.
 In general, no analytical description for this mapping from a hyperparameter configuration to performance exists and gradient information is also not available.
 HPO is therefore a prime example for black-box optimization\index{black-box optimization}[Black-Box Optimization]{.aside} which considers the optimization of a function whose structure and analytical description is unknown, unexploitable or non-existent.
 As a result, the only observable information is the output value (e.g., generalization performance) of the function given an input value (e.g., hyperparameter configuration).
@@ -513,7 +513,7 @@ In general, most black-box optimizers work iteratively, i.e., they sequentially 
 Evolutionary strategies for example maintain a so-called population and generate new points for evaluation by choosing parents from that population and performing recombination operators such as mutation and crossover to generate the offspring of the next generation.
 In general, evolutionary strategies are very suited for black-box optimization, however, if the cost of the evaluation of the black-box function becomes large (e.g., as in HPO), sample efficiency of an optimizer becomes highly relevant.
 
-Bayesian optimization (BO\index{BO}) -- sometimes also called Model Based Optimization (MBO\index{MBO}) -- refers to a class of sample-efficient iterative global black-box optimization algorithms that rely on a surrogate model trained on observed data to model the black-box function.
+`r index("Bayesian optimization", aside = TRUE)` (BO) -- sometimes also called `r index("Model Based Optimization", aside = TRUE)` (MBO) -- refers to a class of sample-efficient iterative global black-box optimization algorithms that rely on a surrogate model trained on observed data to model the black-box function.
 This surrogate model is typically a non-linear regression model that tries to capture the unknown function using limited observed data.
 During each iteration, BO algorithms employ an acquisition function to determine the next candidate point for evaluation.
 This function measures the expected 'utility' of each point within the search space based on the prediction of the surrogate model.
@@ -653,7 +653,7 @@ library(mlr3mbo)
 ```
 
 Local optima (as in our running example visualized in @fig-bayesian-optimization-sinusoidal) pose a significant challenge for many optimization algorithms as they can trap the algorithm, preventing it from escaping to potentially better solutions.
-Bayesian optimization (BO) is an iterative global optimization algorithm that makes use of a so-called surrogate model to model the unknown black-box function.
+BO is an iterative global optimization algorithm that makes use of a so-called surrogate model to model the unknown black-box function.
 After having observed an initial design, the surrogate model is trained on all data points observed so far.
 Then an acquisition function is used to determine which points of the search space are promising candidate(s) that should be evaluated next.
 The acquisition function relies on the mean and standard deviation prediction of the surrogate model and requires no evaluation of the true black-box function and therefore is comparably cheap to optimize.
@@ -1339,7 +1339,7 @@ Real world black-box functions, however, are often noisy\index{noisy Objective}[
 For instance, let's consider a scenario where we are trying to enhance the efficacy of a manufacturing process.
 In this context, the objective function could be the rate of production, and the parameters to adjust could be temperature, pressure and speed of the machinery.
 However, given the inherent variability of the machines, as well as changing environmental conditions achieving the same production rate consistently for a specific machine setting can be challenging.
-Similarly, when optimizing hyperparameters in machine learning, reevaluating the same hyperparameter configuration typically does not produce identical estimates of the generalization performance.
+Similarly, when optimizing hyperparameters in ML, reevaluating the same hyperparameter configuration typically does not produce identical estimates of the generalization performance.
 On the one hand, this can be the result of non-deterministic learning algorithms and different resampling splits.
 On the other hand, recall that the measured generalization performance itself is merely an estimate derived based on a resampling technique (see @sec-performance).
 Consequently, the actual true generalization performance may deviate from the estimated one.

--- a/book/advanced_tuning.qmd
+++ b/book/advanced_tuning.qmd
@@ -1293,7 +1293,7 @@ tuner$optimize(instance)
 ```
 
 The Pareto front is visualized in @fig-pareto-bayesopt.
-Note that the number of selected features can be fractional, as in this example, it is determined through resampling and calculated as an average across the number of selected features per cross-validation fold.
+Note that the number of selected features can be fractional, as in this example, it is determined through resampling and calculated as an average across the number of selected features per CV fold.
 
 ```{r}
 #| echo: false

--- a/book/basics.qmd
+++ b/book/basics.qmd
@@ -6,13 +6,13 @@
 `r authors(chapter)`
 
 In this chapter, we will introduce the `r mlr3` objects and corresponding `r ref_pkg("R6")` classes that implement the essential building blocks of `r index('machine learning', aside = TRUE)` (ML).
-These building blocks include the data (and the methods of creating training and test sets), the ML `r index('algorithm')` (and its training and prediction process), the configuration of a ML algorithm through its `r index('hyperparameters')`, and evaluation measures to assess the quality of predictions.
+These building blocks include the data (and the methods of creating training and test sets), the machine learning `r index('algorithm')` (and its training and prediction process), the configuration of a `r index('machine learning algorithm')` through its `r index('hyperparameters')`, and evaluation measures to assess the quality of predictions.
 
 In the simplest definition, ML is the process of using computer models to learn relationships from data.
 `r index('Supervised learning', aside = TRUE)` is a subfield of ML in which datasets consist of observations (rows in tabular data) that are labeled, which means that each data point includes `r index('features')` (columns in tabular data) and a quantity that we are trying to predict, also called a `r index('target')`.
 A classic example might be trying to predict a car's miles per gallon (the target) based on properties (the features) such as horsepower and the number of gears (we will return to this particular example later).
 In `r mlr3`, we refer to datasets, and their associated metadata as `r index('tasks')` (@sec-tasks).
-The term 'tasks' is used to refer to the ML task (i.e., mathematical problem) that we are trying to solve.
+The term 'tasks' is used to refer to the machine learning task (i.e., mathematical problem) that we are trying to solve.
 Tasks are defined by the features used for prediction and the targets to predict, so there can be multiple tasks associated with any given dataset.
 For example, predicting miles per gallon (mpg) from horsepower is one task, predicting horsepower from miles per gallon is another task, and predicting number of gears from model is yet another task, and so on.
 
@@ -20,10 +20,10 @@ Supervised learning can be further divided into `r index('regression', aside = T
 Other tasks are also encompassed by supervised learning, and these are returned to in @sec-special, we will also consider `r index('unsupervised learning')` tasks in that chapter.
 For any supervised learning task, the goal is to build a `r index('model')` that captures the relationship between features and target and often to `r index('train')` a model to be able to make predictions for new and previously unseen data.
 A `r index('model', aside = TRUE)` is formally a mapping from a feature vector to predictions, such models are induced by passing `r index('training data')` to `r index('machine learning algorithms')`, including `r index('decision trees')`, `r index('support vector machines')`, `r index('neural networks')`, and many more.
-ML algorithms are called `r index('learners', aside = TRUE)` in `r mlr3` (@sec-learners) as given data, they learn models.
+machine learning algorithms are called `r index('learners', aside = TRUE)` in `r mlr3` (@sec-learners) as given data, they learn models.
 Each learner has a parameterized space that potential models are drawn from and during the training process, these parameters are fitted to best match the data.
 For example, the parameters could be the weights given to individual features when training a linear regression model.
-During training, all ML algorithms are `r index('fitted', aside = TRUE)`/`r index('trained', aside = TRUE)` by optimizing a loss-function that quantifies the mismatch between ground truth target values in the training data and the predictions of the model.
+During training, all machine learning algorithms are `r index('fitted', aside = TRUE)`/`r index('trained', aside = TRUE)` by optimizing a loss-function that quantifies the mismatch between ground truth target values in the training data and the predictions of the model.
 
 For a model to be most useful, it should generalize beyond the training data to make 'good' predictions (@sec-predicting) on new and previously 'unseen' (by the model) data.
 The simplest way to determine if a model will generalize to make 'good' predictions for new data, is to split data into `r index('training data', aside = TRUE)` and `r index('test data', aside = TRUE)` -- where the model is trained on the training data and then the separate test data is used to evaluate models in an unbiased way by assessing to what extent the model has learned the true relationships that underlie the data (@sec-performance).
@@ -38,7 +38,7 @@ In the next few sections we will look at the building blocks of `r mlr3` using r
 
 ```{r basics-fig-1, echo=FALSE}
 #| label: fig-ml-abstraction-basics
-#| fig-cap: "General overview of the ML process."
+#| fig-cap: "General overview of the machine learning process."
 #| fig-align: "center"
 #| fig-alt: "A flowchart starting with the task (data), which splits into training- and test sets. The training set is used with the learner to fit a model, which is then used with the test set to make predictions. A performance measure is applied to the predictions and results in a performance estimate. Resampling refers to the repeated application of this process."
 knitr::include_graphics("Figures/ml_abstraction.svg")
@@ -46,13 +46,13 @@ knitr::include_graphics("Figures/ml_abstraction.svg")
 
 ## Tasks {#sec-tasks}
 
-`r index('Tasks')` are objects that contain the (usually tabular) data and additional metadata that define a ML problem.
-The `r index('metadata')` contain, for example, the name of the target feature for supervised ML problems.
+`r index('Tasks')` are objects that contain the (usually tabular) data and additional metadata that define a machine learning problem.
+The `r index('metadata')` contain, for example, the name of the target feature for supervised machine learning problems.
 This information is used automatically by operations that can be performed on a task so that for example the user does not have to specify the prediction target every time a model is trained.
 
 ### Constructing Tasks {#sec-tasks-built-in}
 
-`r mlr3` includes a few predefined ML tasks in the `r ref("mlr_tasks", aside = TRUE)` `Dictionary`.
+`r mlr3` includes a few predefined machine learning tasks in the `r ref("mlr_tasks", aside = TRUE)` `Dictionary`.
 
 ```{r basics-001}
 mlr_tasks
@@ -92,7 +92,7 @@ The `target` argument specifies the prediction target column.
 The `id` argument is optional and specifies an identifier for the task that is used in plots and summaries; if omitted the variable name of the data will be used as the `id`.
 
 :::{.callout-tip}
-As many ML models do not work properly with arbitrary `r link("https://en.wikipedia.org/wiki/UTF-8", "UTF8 names")`, `r mlr3` defaults to throw an error if any of the column names passed to `r ref("as_task_regr()")` (and other task constructors) contain a non-ASCII character or do not comply with R's variable naming scheme.
+As many machine learning models do not work properly with arbitrary `r link("https://en.wikipedia.org/wiki/UTF-8", "UTF8 names")`, `r mlr3` defaults to throw an error if any of the column names passed to `r ref("as_task_regr()")` (and other task constructors) contain a non-ASCII character or do not comply with R's variable naming scheme.
 Therefore, we recommend converting names with `r ref("make.names()")` if possible, but if not then you can bypass this check in` r mlr3` by setting `options(mlr3.allow_utf8_names = TRUE)` (but do not be surprised if an underlying package implementation throws up a related error).
 :::
 
@@ -221,7 +221,7 @@ task_mtcars_small$data()
 
 ## Learners {#sec-learners}
 
-Objects of class `r ref("Learner", aside = TRUE)` provide a unified interface to many popular ML algorithms in R.
+Objects of class `r ref("Learner", aside = TRUE)` provide a unified interface to many popular machine learning algorithms in R.
 The `r ref("mlr_learners", aside = TRUE)` dictionary contains all the learners available in `mlr3`, we will discuss the available learners in @sec-lrns-add, for now we will just use a regression tree learner as an example to discuss the `Learner` interface.
 As with tasks, you can access learners from the dictionary with a single sugar function, in this case `r ref("lrn()", aside = TRUE)`.
 
@@ -237,7 +237,7 @@ All `Learner` objects include the following metadata, which can be seen in the o
 * `$predict_types`: the types of prediction that the model can make (@sec-predicting).
 * `$param_set`: the set of available hyperparameters (@sec-param-set).
 
-To run an ML experiment, learners pass through two stages (@fig-basics-learner):
+To run an machine learning experiment, learners pass through two stages (@fig-basics-learner):
 
 * `r index('Training', aside = TRUE)`: A training `Task` is passed to the learner's `$train()`  function which trains and stores a `r index('model')`, i.e., the learned relationship of the features to the target.
 * `r index('Predicting', aside = TRUE)`: New data, often a different partition of the original dataset, is passed to the `$predict()` method of the trained learner to predict the target values.
@@ -358,13 +358,13 @@ learner_lm$predict(task_mtcars, splits$test)
 
 We will see prediction types playing an even bigger part in classification in @sec-basics-classif-learner.
 
-The final step of the basic ML workflow (@fig-ml-abstraction-basics) is to evaluate the quality of predictions to see if our trained model is any 'good'.
+The final step of the basic machine learning workflow (@fig-ml-abstraction-basics) is to evaluate the quality of predictions to see if our trained model is any 'good'.
 We will cover basic evaluation in @sec-eval and then more advanced evaluation for data resampling and model comparison in @sec-performance.
-But first we will cover the final element that makes ML models powerful predictive tools, which is their hyperparameters, which give users control over the fitting and predicting process and when set correctly can result in more accurate models.
+But first we will cover the final element that makes machine learning models powerful predictive tools, which is their hyperparameters, which give users control over the fitting and predicting process and when set correctly can result in more accurate models.
 
 ### Hyperparameters {#sec-param-set}
 
-`Learner`s encapsulate an ML algorithm and its `r index('hyperparameters')`, which are free parameters that can be set by the user to affect *how* the algorithm is run.
+`Learner`s encapsulate a machine learning algorithm and its `r index('hyperparameters')`, which are free parameters that can be set by the user to affect *how* the algorithm is run.
 Hyperparameters may affect how a model is trained or how it makes predictions and deciding which hyperparameters to set can require expert knowledge though often there is an element of trial and error.
 Hyperparameters are hugely important to a model performing well and therefore setting hyperparameters manually is rarely a good idea.
 In practice, automated hyperparameter optimization is more common, which we will return to in @sec-optimization.
@@ -524,7 +524,7 @@ In general, a model that does not outperform a baseline is a 'bad' model, on the
 
 ## Evaluation {#sec-eval}
 
-Perhaps *the most* important  step of the ML workflow is evaluating model performance.
+Perhaps *the most* important  step of the machine learning workflow is evaluating model performance.
 Without this step, we would have no way to know if our trained model makes very accurate predictions, is worse than randomly guessing, or somewhere in between.
 We will continue with our decision tree example to establish if the quality of our predictions is 'good', first we will rerun the above code so it is easier to follow along.
 
@@ -684,7 +684,7 @@ In the next section, we will extend the building block of `r mlr3` to consider c
 
 `r index('Classification')` problems are ones in which a model tries to predict a discrete, categorical target, as opposed to a continuous, numeric quantity.
 For example, predicting the species of penguin from its physical characteristics would be a classification problem as there are only a finite number of species.
-`mlr3` ensures that the interface for all tasks is as similar as possible (if not identical) and therefore we will not repeat any content from the previous section but will just focus on differences that make classification a unique ML problem.
+`mlr3` ensures that the interface for all tasks is as similar as possible (if not identical) and therefore we will not repeat any content from the previous section but will just focus on differences that make classification a unique machine learning problem.
 We will first demonstrate the similarities between regression and classification by performing an experiment very similar to the one in @sec-basics-regr-experiment using code that will now be familiar to you.
 We will then move to differences in tasks, learners and predictions, before looking at `r index('thresholding')`, which is a method specific to classification.
 
@@ -1008,7 +1008,7 @@ The list of learners included in `r mlr3` is deliberately small to avoid large s
 
 * Featureless learner (`regr.featureless`/`classif.featureless`), which are implemented in `r mlr3` and are baseline learners used for model comparison or as `r index('fallback learners')` (@sec-fallback). The former predicts the mean of the target values in the training set for all new observations, the latter predicts the most frequent label.
 * Debug learners (`regr.debug`/`classif.debug`), which are implemented in `r mlr3` and used only to debug code (@sec-error-handling).
-* Classification and regression trees (CART) (`regr.rpart`/`classif.rpart`).
+* Classification and regression trees (also known as CART) (`regr.rpart`/`classif.rpart`).
 
 The `r mlr3learners` package contains a selection of algorithms (and select implementations) chosen by the mlr team that we recommend as a good starting point for most experiments:
 
@@ -1050,9 +1050,9 @@ as.data.table(mlr_learners)[task_type == "regr" &
 
 In this chapter we covered the building blocks of `mlr3`.
 We first introduced basic ML methodology and then showed how this is implemented in `r mlr3`
-We began by looking at the `r ref("Task")` class, which is used to define ML tasks or problems to solve.
-We then looked at the `r ref("Learner")` class, which encapsulates ML algorithms, hyperparameters, and other metainformation.
-Finally we consider how to evaluate ML models with objects from the `r ref("Measure")` class.
+We began by looking at the `r ref("Task")` class, which is used to define machine learning tasks or problems to solve.
+We then looked at the `r ref("Learner")` class, which encapsulates machine learning algorithms, hyperparameters, and other metainformation.
+Finally we consider how to evaluate machine learning models with objects from the `r ref("Measure")` class.
 After looking at regression implementations, we extended all the above to the classification setting, before finally looking at some extra details about tasks and the algorithms that are implemented across `mlr3`.
 The rest of this book will build on the basic elements seen in this chapter, starting with more advanced model comparison methods in @sec-performance before moving to improving model performance with automated hyperparameter tuning in @sec-optimization.
 @tbl-basics-api summarizes the most important functions and methods seen in this chapter.

--- a/book/basics.qmd
+++ b/book/basics.qmd
@@ -5,10 +5,10 @@
 `r chapter = "Data and Basic Modeling"`
 `r authors(chapter)`
 
-In this chapter, we will introduce the `r mlr3` objects and corresponding `r ref_pkg("R6")` classes that implement the essential building blocks of `r index("machine learning")` (ML).
+In this chapter, we will introduce the `r mlr3` objects and corresponding `r ref_pkg("R6")` classes that implement the essential building blocks of `r index('machine learning', aside = TRUE)` (ML).
 These building blocks include the data (and the methods of creating training and test sets), the ML `r index('algorithm')` (and its training and prediction process), the configuration of a ML algorithm through its `r index('hyperparameters')`, and evaluation measures to assess the quality of predictions.
 
-In the simplest definition, `r index('machine learning', aside = TRUE)` is the process of using computer models to learn relationships from data.
+In the simplest definition, ML is the process of using computer models to learn relationships from data.
 `r index('Supervised learning', aside = TRUE)` is a subfield of ML in which datasets consist of observations (rows in tabular data) that are labeled, which means that each data point includes `r index('features')` (columns in tabular data) and a quantity that we are trying to predict, also called a `r index('target')`.
 A classic example might be trying to predict a car's miles per gallon (the target) based on properties (the features) such as horsepower and the number of gears (we will return to this particular example later).
 In `r mlr3`, we refer to datasets, and their associated metadata as `r index('tasks')` (@sec-tasks).
@@ -38,7 +38,7 @@ In the next few sections we will look at the building blocks of `r mlr3` using r
 
 ```{r basics-fig-1, echo=FALSE}
 #| label: fig-ml-abstraction-basics
-#| fig-cap: "General overview of the machine learning process."
+#| fig-cap: "General overview of the ML process."
 #| fig-align: "center"
 #| fig-alt: "A flowchart starting with the task (data), which splits into training- and test sets. The training set is used with the learner to fit a model, which is then used with the test set to make predictions. A performance measure is applied to the predictions and results in a performance estimate. Resampling refers to the repeated application of this process."
 knitr::include_graphics("Figures/ml_abstraction.svg")

--- a/book/basics.qmd
+++ b/book/basics.qmd
@@ -5,10 +5,10 @@
 `r chapter = "Data and Basic Modeling"`
 `r authors(chapter)`
 
-In this chapter, we will introduce the `r mlr3` objects and corresponding `r ref_pkg("R6")` classes that implement the essential building blocks of `r index('machine learning', aside = TRUE)` (ML).
+In this chapter, we will introduce the `r mlr3` objects and corresponding `r ref_pkg("R6")` classes that implement the essential building blocks of machine learning.
 These building blocks include the data (and the methods of creating training and test sets), the machine learning `r index('algorithm')` (and its training and prediction process), the configuration of a `r index('machine learning algorithm')` through its `r index('hyperparameters')`, and evaluation measures to assess the quality of predictions.
 
-In the simplest definition, ML is the process of using computer models to learn relationships from data.
+In the simplest definition, `r index('machine learning', aside = TRUE)` (ML) is the process of using computer models to learn relationships from data.
 `r index('Supervised learning', aside = TRUE)` is a subfield of ML in which datasets consist of observations (rows in tabular data) that are labeled, which means that each data point includes `r index('features')` (columns in tabular data) and a quantity that we are trying to predict, also called a `r index('target')`.
 A classic example might be trying to predict a car's miles per gallon (the target) based on properties (the features) such as horsepower and the number of gears (we will return to this particular example later).
 In `r mlr3`, we refer to datasets, and their associated metadata as `r index('tasks')` (@sec-tasks).

--- a/book/fairness.qmd
+++ b/book/fairness.qmd
@@ -200,11 +200,11 @@ The functionality introduced above is intended to help users investigate their m
 Fairness metrics can not be used to prove or guarantee fairness.
 Deciding whether a model is fair requires additional investigation, such as deciding what the measured quantities actually represent for an individual in the real world and what other biases might exist in the data that could lead to discrepancies in how e.g. covariates or the label are measured.
 
-The simplicity of fairness metrics mean they should only be used for exploratory purposes only, and practitioners should not solely rely on them to make decisions about employing an ML model or assessing whether a system is fair.
+The simplicity of fairness metrics mean they should only be used for exploratory purposes only, and practitioners should not solely rely on them to make decisions about employing an machine learning model or assessing whether a system is fair.
 Instead, practitioners should look beyond the model and consider the data used for training and the process of data and label acquisition.
 To help in this process, it is important to provide robust documentation for data collection methods, the resulting data, and the models resulting from this data.
 Informing auditors about those aspects of a deployed model can lead to better assessment of a model's fairness.
-Questionnaires for ML models and data sets have been previously proposed in literature and are available in `r mlr3fairness` from automated report templates (`r ref("report_modelcard()")` and `r ref("report_datasheet()")`) using R markdown for data sets and ML models.
+Questionnaires for machine learning models and data sets have been previously proposed in literature and are available in `r mlr3fairness` from automated report templates (`r ref("report_modelcard()")` and `r ref("report_datasheet()")`) using R markdown for data sets and machine learning models.
 In addition, we provide a template for a `r index('fairness report', aside = TRUE)`, `r ref("report_fairness()", aside = TRUE)` which includes many fairness metrics and visualizations to provide a good starting point for generating a fairness report inspired by the Aequitas Toolkit [@2018aequitas].
 
 We hope that pairing the functionality available in `r mlr3fairness` with additional exploratory data analysis, a solid understanding of the societal context in which the decision is made and integrating additional tools (e.g. interpretability methods seen in @sec-interpretation) might help to mitigate or diminish unfairness in systems deployed in the future.

--- a/book/feature-selection.qmd
+++ b/book/feature-selection.qmd
@@ -242,7 +242,7 @@ learner = as_learner(graph)
 learner$train(task)
 ```
 
-Pipelines can also be used to apply hyperparameter optimization (@sec-optimization) to the filter, i.e. tune the filter threshold to optimize the feature selection regarding prediction performance, and to embed this in resampling.
+Pipelines can also be used to apply HPO (@sec-optimization) to the filter, i.e. tune the filter threshold to optimize the feature selection regarding prediction performance, and to embed this in resampling.
 We first combine a filter with a learner,
 
 ```{r feature-selection-013}
@@ -309,7 +309,7 @@ In this chapter, we cover how to
 * run it or fuse it with a `Learner` via an `AutoFSelector`.
 
 ::: {.callout-tip}
-Wrapper-based feature selection is very similar to hyperparameter optimization (@sec-optimization).
+Wrapper-based feature selection is very similar to HPO (@sec-optimization).
 The major difference is that we search for well-performing feature subsets instead of hyperparameter configurations.
 We will see below, that we can even use the same terminators, that some feature selection algorithms are similar to tuners and that we can also optimize multiple performance measures with feature selection.
 :::
@@ -334,7 +334,7 @@ instance = fselect(
 )
 ```
 
-In contrast to hyperparameter optimization (@sec-optimization), `fselect` directly starts the optimization and selects features.
+In contrast to HPO (@sec-optimization), `fselect` directly starts the optimization and selects features.
 To show all analyzed feature subsets and the corresponding performance, we use `as.data.table(instance$archive)`.
 In this example, the `batch_nr` column represents the iteration of the sequential forward selection and we start by looking at the first iteration.
 
@@ -413,7 +413,7 @@ The following terminator are available:
 * Terminate when feature selection does not improve (`r ref("TerminatorStagnation")`)
 * A combination of the above in an *ALL* or *ANY* fashion (`r ref("TerminatorCombo")`)
 
-See also the description of terminators in hyperparameter optimization (@sec-terminator).
+See also the description of terminators in HPO (@sec-terminator).
 Above we used the sugar function `r ref("trm")` to select `r ref("TerminatorEvals")` with 20 evaluations.
 
 To start the feature selection, we still need to select an algorithm which are defined via the `FSelector` class, described in the next section.
@@ -494,7 +494,7 @@ However, these two subsets will generally not coincide, i.e. the subset with hig
 With `r mlr3fselect`, the result is the pareto-optimal solution, i.e. the best feature subset for each of the criteria that is not dominated by another subset.
 For the example with classification accuracy and training time, a feature subset that is best in accuracy *and* training time will dominate all other subsets and thus will be the only pareto-optimal solution.
 If, however, different subsets are best in the two criteria, both subsets are pareto-optimal.
-Again, we point out the similarity with hyperparameter optimization and refer to multi-objective hyperparameter optimization (see @sec-multi-metrics-tuning and @karl2022).
+Again, we point out the similarity with HPO and refer to multi-objective hyperparameter optimization (see @sec-multi-metrics-tuning and @karl2022).
 
 In the following example, we will perform feature selection on the sonar dataset. This time, we will use `r ref("FSelectInstanceMultiCrit")` to select a subset of features that has high sensitivity, i.e. TPR, and high specificity, i.e. TNR. The feature selection process with multiple criteria is similar to that with a single criterion, except that we select two measures to be optimized:
 
@@ -549,7 +549,7 @@ This time however, we pass it to `r ref("benchmark()")` to compare the optimized
 This way, the `AutoFSelector` will do its resampling for feature selection on the training set of the respective split of the outer resampling.
 The learner then undertakes predictions using the test set of the outer resampling.
 Here, the outer resampling refers to the resampling specified in `benchmark()`, whereas the inner resampling is that specified in `auto_fselector()`.
-This is called nested resampling (see @sec-nested-resampling in hyperparameter optimization) and yields unbiased performance measures, as the observations in the test set have not been used during feature selection or fitting of the respective learner.
+This is called nested resampling (see @sec-nested-resampling) and yields unbiased performance measures, as the observations in the test set have not been used during feature selection or fitting of the respective learner.
 
 In the call to `benchmark()`, we compare our wrapped learner `at` with a normal logistic regression `lrn("classif.log_reg")`.
 For that, we create a benchmark grid with the task, the learners and a 3-fold cross validation on the `r ref("mlr_tasks_sonar", text = "sonar")` data.
@@ -604,7 +604,7 @@ We introduced filter and wrapper methods, combined feature selection with pipeli
 * A more formal and detailed introduction to filters and wrappers is given in @guyon2003.
 * @bommert2020 perform a benchmark of filter methods.
 * Filters can be used as part of a machine learning pipeline (@sec-pipelines).
-* Filters can be optimized with hyperparameter optimization (@sec-optimization).
+* Filters can be optimized with HPO (@sec-optimization).
 
 ## Exercises
 

--- a/book/feature-selection.qmd
+++ b/book/feature-selection.qmd
@@ -496,7 +496,7 @@ For the example with classification accuracy and training time, a feature subset
 If, however, different subsets are best in the two criteria, both subsets are pareto-optimal.
 Again, we point out the similarity with hyperparameter optimization and refer to multi-objective hyperparameter optimization (see @sec-multi-metrics-tuning and @karl2022).
 
-In the following example, we will perform feature selection on the sonar dataset. This time, we will use `r ref("FSelectInstanceMultiCrit")` to select a subset of features that has high sensitivity, i.e. true positive rate (TPR), and high specificity, i.e. true negative rate (TNR). The feature selection process with multiple criteria is similar to that with a single criterion, except that we select two measures to be optimized:
+In the following example, we will perform feature selection on the sonar dataset. This time, we will use `r ref("FSelectInstanceMultiCrit")` to select a subset of features that has high sensitivity, i.e. TPR, and high specificity, i.e. TNR. The feature selection process with multiple criteria is similar to that with a single criterion, except that we select two measures to be optimized:
 
 ```{r feature-selection-026}
 instance = fsi(

--- a/book/interpretation.qmd
+++ b/book/interpretation.qmd
@@ -19,7 +19,7 @@ Interpretation methods are valuable from multiple perspectives:
 changes when changing the input.
 1. For justification purposes or to assess fairness, e.g., to inspect whether the model adversely affects certain subpopulations or individuals. This point is not subject of this chapter, but will be discussed in detail in @sec-fairness.
 
-In this chapter, we focus on some important methods from the field of interpretable ML that can be applied to `mlr3` objects `r index("post-hoc")`, i.e. after the model has been trained, and are `r index("model-agnostic")`, i.e. applicable to any model without any restriction to a specific model class.
+In this chapter, we focus on some important methods from the field of `r index('interpretable machine learning', aside = TRUE)` (IML) that can be applied to `mlr3` objects `r index("post-hoc")`, i.e. after the model has been trained, and are `r index("model-agnostic")`, i.e. applicable to any model without any restriction to a specific model class.
 We will focus on methods implemented in the following three packages, all three of which interface with `mlr3`:
 
 -   `r ref_pkg("iml")` presented in @sec-iml,
@@ -29,7 +29,7 @@ We will focus on methods implemented in the following three packages, all three 
 The `r ref_pkg("iml")` and `r ref_pkg("DALEX")` packages offer similar functionality but differ in design choices in that `r ref_pkg("iml")` makes use of the `R6` class system whereas `r ref_pkg("DALEX")` is based on the S3 class system.
 `r ref_pkg("counterfactuals")` also makes use of `R6`.
 In contrast to `r ref_pkg("iml")` and `r ref_pkg("counterfactuals")`, `r ref_pkg("DALEX")` focuses on comparing multiple predictive models, usually of different types, on the same plot, which is a model comparison-oriented approach, often referred to as Rashomon perspective.
-We will only provide a brief overview to the methods discussed below, we recommend @Molnar2022 as a comprehensive introductory book about interpretable ML.
+We will only provide a brief overview to the methods discussed below, we recommend @Molnar2022 as a comprehensive introductory book about IML.
 
 As a running example throughout this chapter, we will consider a gradient boosting machine (GBM) fit on half the features in the `german_credit` task:
 
@@ -50,8 +50,8 @@ For prediction-based methods that do not require performance estimation such as 
 
 ## The `iml` Package {#sec-iml}
 
-The `r ref_pkg("iml")` package [@Molnar2018] implements a variety of model-agnostic interpretation methods for a unified interface to the implemented methods and facilitates the analysis and interpretation of ML models.
-In theory, `r ref_pkg("iml")` supports ML models (for classification or regression) fitted by *any* R package, and in particular all `mlr3` models are supported by wrapping learners in an `r ref("iml::Predictor")` object, which unifies the input-output behavior of the trained models.
+The `r ref_pkg("iml")` package [@Molnar2018] implements a variety of model-agnostic interpretation methods for a unified interface to the implemented methods and facilitates the analysis and interpretation of machine learning models.
+In theory, `r ref_pkg("iml")` supports machine learning models (for classification or regression) fitted by *any* R package, and in particular all `mlr3` models are supported by wrapping learners in an `r ref("iml::Predictor")` object, which unifies the input-output behavior of the trained models.
 This object contains the prediction model as well as the data used for analyzing the model and producing the desired explanation.
 We construct the `r ref("iml::Predictor")` object using our trained learner and heldout test data:
 
@@ -101,8 +101,8 @@ These methods can be distinguished between local and global feature effect metho
 In contrast, `r index('local feature effect methods')` address the question of how a *single* prediction of a given observation changes when a feature value is changed.
 To a certain extent, local feature effect methods can reveal interactions in the model that become visible when the local effects are heterogeneous, i.e., if changes in the local effect are different across the observations.
 
-`r index('Partial dependence (PD) plots', aside = TRUE)` [@Friedman2001pdp] can be used to visualize global feature effects by visualizing how model predictions change on average when varying the feature values of a given feature of interest.
-`r index('Individual conditional expectation (ICE) curves', aside = TRUE)` [@Goldstein2015ice] (a.k.a. Ceteris Paribus Effects \index{ceteris paribus|see{Individual conditional expectation (ICE) curves}}) are a local feature effects method that display how the prediction of a *single* observation changes when varying a feature of interest while all other features stay constant.
+`r index('Partial dependence', aside = TRUE)` (PD) plots [@Friedman2001pdp] can be used to visualize global feature effects by visualizing how model predictions change on average when varying the feature values of a given feature of interest.
+`r index('Individual conditional expectation', aside = TRUE)` (ICE) curves  [@Goldstein2015ice] (a.k.a. Ceteris Paribus Effects \index{ceteris paribus|see{Individual conditional expectation (ICE) curves}}) are a local feature effects method that display how the prediction of a *single* observation changes when varying a feature of interest while all other features stay constant.
 @Goldstein2015ice demonstrated that the PD plot is the average of ICE curves.
 ICE curves are constructed by taking a single observation and feature of interest, and then replacing the feature's value by another value and plotting the new prediction, this is then repeated for many feature values (e.g., across an equidistant grid of the feature's value range).
 The x-axis of an ICE curve visualizes the set of replacement feature values and the y-axis is the model prediction.
@@ -572,7 +572,7 @@ Even with fixed hyperparameters, the underlying data set or the initial seed can
 
 The `german_credit` task is low-dimensional with a limited number of observations.
 Applying interpretation methods off-the-shelf to higher dimensional datasets is often not feasible due to the enormous computational costs.
-That is why in previous years more efficient methods were proposed, e.g., Shapley value computations based on kernel-based estimators (SHAP).
+That is why in previous years more efficient methods were proposed, e.g., Shapley value computations based on kernel-based estimators.
 Another challenge is that the high-dimensional IML output generated for high-dimensional datasets can overwhelm users.
 If the features can be meaningfully grouped, grouped versions of the methods, e.g. the grouped feature importance proposed by @Au2022, can be applied.
 

--- a/book/interpretation.qmd
+++ b/book/interpretation.qmd
@@ -5,7 +5,7 @@
 `r chapter = "Model Interpretation"`
 `r authors(chapter)`
 
-The increasing availability of data and software frameworks to create predictive models has allowed the widespread adoption of machine learning in many applications.
+The increasing availability of data and software frameworks to create predictive models has allowed the widespread adoption of ML in many applications.
 However, high predictive performance of such models often comes at the cost of `r index("interpretability")`:
 Many trained models by default do not provide further insights into the model and are often too complex to be understood by humans such that questions like ''What are the most important features and how do they influence a prediction?'' cannot be directly answered.
 This lack of explanations hurts trust and creates barriers to adapt predictive models, especially in critical areas with decisions affecting human life, such as credit scoring or medical applications.

--- a/book/intro.qmd
+++ b/book/intro.qmd
@@ -25,8 +25,8 @@ install.packages("mlr3")
 ## How to Use This Book {#howtouse}
 
 The mlr3 ecosystem is the result of many years of methodological and applied research and improving the design and implementation of the packages over the years.
-This book describes the resulting features of the `r mlr3verse` and discusses best practices for ML, technical implementation details, extension guidelines, and in-depth considerations for optimizing ML.
-It is suitable for a wide range of readers and levels of ML expertise but we assume that users of `r mlr3` have taken an introductory machine learning course or have the equivalent expertise and some basic experience with R.
+This book describes the resulting features of the `r mlr3verse` and discusses best practices for machine learning, technical implementation details, extension guidelines, and in-depth considerations for optimizing machine learning.
+It is suitable for a wide range of readers and levels of machine learning expertise but we assume that users of `r mlr3` have taken an introductory machine learning course or have the equivalent expertise and some basic experience with R.
 A background in computer science or statistics is beneficial for understanding the advanced functionality described in the later chapters of this book, but not required.
 A comprehensive introduction for those new to machine learning can be found in [@james2013introduction], and [@Wickham2017R] gives a comprehensive introduction to data science in R.
 This book may also be helpful for both **practitioners** who want to quickly apply machine learning algorithms and **researchers** who want to implement, benchmark, and compare their new methods in a structured environment.
@@ -41,9 +41,9 @@ In @sec-basics we will cover the basic classes in `r mlr3`, including `Learner` 
 @sec-performance will take evaluation a step further to include discussions about resampling -- robust strategies for measuring model performance -- and benchmarking -- experiments for comparing multiple models.
 
 **Part II: Tuning and Feature Selection**<br>
-In this part of the book we look at more advanced methodology that is essential to developing powerful ML models with good predictive ability.
+In this part of the book we look at more advanced methodology that is essential to developing powerful machine learning models with good predictive ability.
 We demonstrate how to manually make use of these methods using `mlr3` code and also the automated implementations that are included to make your machine learning workflow even more efficient.
-@sec-optimization introduces hyperparameter optimization (HPO), which is the process of tuning model hyperparameters to obtain better model performance. Tuning is implemented via the `r mlr3tuning` package, which also includes methods for automating complex tuning processes, including nested resampling.
+@sec-optimization introduces hyperparameter optimization, which is the process of tuning model hyperparameters to obtain better model performance. Tuning is implemented via the `r mlr3tuning` package, which also includes methods for automating complex tuning processes, including nested resampling.
 The performance of machine learning models can be improved by tuning hyperparameters but also by carefully selected features from the training dataset. @sec-feature-selection introduces manual and automated feature selection with filters and wrappers implemented in `r mlr3filters` and `r mlr3fselect`.
 For readers interested in taking a deep dive into tuning, @sec-optimization-advanced discusses advanced tuning methods including error handling, multi-objective tuning, and tuning with Hyperband and Bayesian Optimization methods.
 
@@ -122,7 +122,7 @@ Now let us see this in practice with our first example.
 
 ## mlr3 Example
 
-The `mlr3` universe includes a wide range of tools taking you from basic ML to complex experiments.
+The `mlr3` universe includes a wide range of tools taking you from basic machine learning to complex experiments.
 To get started, here is an example of the most simple functionality -- training a model and making predictions.
 
 ```{r C0 egBasic}
@@ -204,7 +204,7 @@ bma$learner_id = rep(c("RF", "Stack"), 2)
 bma
 ```
 
-In this (much more complex!) example we chose two tasks and two learners and used automated tuning to optimize the number of trees in the random forest learner (@sec-optimization), and an ML pipeline that imputes missing data, collapses factor levels, and creates stacked models (@sec-pipelines and @sec-pipelines-nonseq).
+In this (much more complex!) example we chose two tasks and two learners and used automated tuning to optimize the number of trees in the random forest learner (@sec-optimization), and an machine learning pipeline that imputes missing data, collapses factor levels, and creates stacked models (@sec-pipelines and @sec-pipelines-nonseq).
 We also showed basic features like loading learners (@sec-basics) and choosing resampling strategies for benchmarking (@sec-performance).
 Finally, we compared the performance of the models using the mean accuracy on the test set.
 
@@ -218,14 +218,14 @@ In addition, `mlr3` includes advanced functionality such as hyperparameter tunin
 Parallelization of many operations is natively supported (@sec-parallelization).
 
 `r mlr3` has similar overall aims to `r ref_pkg("caret")` and `r ref_pkg("tidymodels")` for R, `r link("https://scikit-learn.org/", "scikit-learn")` for Python, and `r link("https://alan-turing-institute.github.io/MLJ.jl/dev/", "MLJ")` for Julia.
-In general `r mlr3` is designed to provide more flexibility than other ML frameworks while still offering easy ways to use advanced functionality.
-While `r ref_pkg("tidymodels")` in particular makes it very easy to perform simple ML tasks, `r mlr3` is more geared towards advanced ML.
+In general `r mlr3` is designed to provide more flexibility than other machine learning frameworks while still offering easy ways to use advanced functionality.
+While `r ref_pkg("tidymodels")` in particular makes it very easy to perform simple machine learning tasks, `r mlr3` is more geared towards advanced ML.
 
 ## From mlr to mlr3
 
 The `r ref_pkg("mlr")`\index{mlr} package [@mlr] was first released to `r link("https://cran.r-project.org", "CRAN")` in 2013, with the core design and architecture dating back somewhat further.
 Over time, the addition of many features has led to a considerably more complex design that made it harder to build, maintain, and extend than we had hoped for.
-In hindsight, we saw that some design and architecture choices in `r ref_pkg("mlr")` made it difficult to support new features, in particular with respect to ML pipelines.
+In hindsight, we saw that some design and architecture choices in `r ref_pkg("mlr")` made it difficult to support new features, in particular with respect to machine learning pipelines.
 Furthermore, the R ecosystem and packages within it, such as `r ref_pkg("data.table")`, had undergone major changes after the initial design of `r ref_pkg("mlr")`.
 
 It would have been difficult to integrate all of these changes into the original design of `r ref_pkg("mlr")`.
@@ -240,7 +240,7 @@ The packages in the ecosystem are less tightly coupled, making them easier to ma
 
 We follow these general design principles in the `r mlr3` package and `r mlr3verse` ecosystem.
 
-*   **Object-oriented programming (OOP)**.
+*   **Object-oriented programming**.
 We embrace `r ref_pkg("R6")` for a clean, object-oriented design, object state-changes, and reference semantics.
 This means that the state of common objects (e.g. tasks (@sec-tasks) and learners (@sec-learners)) is encapsulated within the object, for example to keep track of whether a model has been trained, without the user having to worry about this.
 We also use inheritance to specialize objects, e.g. all learners are derived from a common base class that provides basic functionality.
@@ -258,14 +258,14 @@ One of the main maintenance burdens for `r ref_pkg("mlr")` was to keep up with c
 We require far fewer packages in `r mlr3`, which makes installation and maintenance easier.
 We still provide the same functionality, but it is split into more packages that have fewer dependencies individually.
 *   **Separation of computation and presentation**.
-Most packages of the `r mlr3` ecosystem focus on processing and transforming data, applying ML algorithms, and computing results.
+Most packages of the `r mlr3` ecosystem focus on processing and transforming data, applying machine learning algorithms, and computing results.
 Our core packages do not provide visualizations because their dependencies would make installation unnecessarily complex, especially on headless servers (i.e., computers without a monitor where graphical libraries are not installed).
 For the same reason, visualizations of data and results are provided in the extra package `r mlr3viz`, which avoids dependencies on `ggplot2`.
 
 ## The `mlr3` Ecosystem
 
 Throughout this book we often refer to `mlr3`, which does not refer to the single `r mlr3` base package but all the packages in our ecosystem.
-The `r mlr3` *package* provides the base functionality that the rest of the ecosystem depends on for building more advanced ML tools.
+The `r mlr3` *package* provides the base functionality that the rest of the ecosystem depends on for building more advanced machine learning tools.
 @fig-mlr3verse shows the packages in the `mlr3verse` that extend `r mlr3` with capabilities for preprocessing, pipelining, visualizations, additional learners, additional task types, and more.
 
 <!-- FIXME - NEED TO REDESIGN FOR PDF -->
@@ -285,7 +285,7 @@ As well as packages within the `mlr3` ecosystem, software in the `mlr3verse` als
 *   `r ref_pkg("digest")`: Cryptographic hash functions.
 *   `r ref_pkg("uuid")`: Generation of universally unique identifiers.
 *   `r ref_pkg("lgr")`: Configurable logging library.
-*   `r ref_pkg("mlbench")` and `r ref_pkg("palmerpenguins")`: More ML data sets.
+*   `r ref_pkg("mlbench")` and `r ref_pkg("palmerpenguins")`: More machine learning data sets.
 *   `r ref_pkg("evaluate")`: For capturing output, warnings, and exceptions (@sec-error-handling).
 *   `r ref_pkg("future")` / `r ref_pkg("future.apply")` / `r ref_pkg("parallelly")`: For parallelization (@sec-parallelization).
 
@@ -321,7 +321,7 @@ For an in-depth introduction, we recommend the data.table vignette @datatable.
 
 ### R6 for Beginners {#sec-r6}
 
-`r ref_pkg("R6")` is one of R's more recent paradigm for object-oriented programming (OOP).
+`r ref_pkg("R6")` is one of R's more recent paradigm for object-oriented programming.
 It addresses shortcomings of earlier OO implementations in R, such as S3, which we used in `r ref_pkg("mlr")`.
 If you have done any (class) object-oriented programming before, R6 should feel familiar.
 We focus on the parts of R6 that you need to know to use `mlr3`.

--- a/book/large_benchmarking.qmd
+++ b/book/large_benchmarking.qmd
@@ -18,7 +18,7 @@ if (!dir.exists(file.path("openml", "manual"))) {
 options(mlr3oml.cache = file.path("openml", "cache"))
 ```
 
-In the world of machine learning, there are many methods that are hard to evaluate using mathematical analysis alone.
+In the world of ML, there are many methods that are hard to evaluate using mathematical analysis alone.
 Even if formal analysis is successful, it is often an open question whether real-world datasets satisfy the necessary assumptions for the theorems to hold.
 Consequently, researchers resort to conducting benchmark experiments to answer fundamental scientific questions.
 Such studies evaluate different algorithms on a wide range of datasets, with the aim of identifying which method performs best.
@@ -203,7 +203,7 @@ OpenML tasks are built on top of OpenML datasets and additionally specify the ta
 Similar to mlr3, OpenML has different types of tasks, such as regression or classification.
 A task associated with the adult data from earlier has ID `r link("https://openml.org/t/359983", "359983")`.
 We can load the object using the `r ref("mlr3oml::otsk()")` function, which returns an `r ref("OMLTask")` object.
-Note that this task object is different from an `mlr3` `r ref("Task")` and cannot directly be used for machine learning.
+Note that this task object is different from an `mlr3` `r ref("Task")` and cannot directly be used for ML.
 However, it contains all required information and there is a convenient converter, as shown below.
 
 ```{r large_benchmarking-009}
@@ -399,7 +399,7 @@ Not only are the resample experiments independent, but even their individual ite
 However, if the experiment is large, parallelization on a local machine as shown in @sec-parallelization often is not enough and using a distributed computing system, such as an HPC cluster, is required.
 While access to HPC clusters is widespread at universities and research-driven companies, the effort required to work on these systems is still considerable.
 The R package `r ref_pkg("batchtools")` provides a framework to simplify running large batches of computational experiments in parallel from R.
-It is highly flexible, making it suitable for a wide range of computational experiments, including machine learning, optimisation, simulation, and more.
+It is highly flexible, making it suitable for a wide range of computational experiments, including ML, optimisation, simulation, and more.
 
 :::{.callout-tip}
 In @sec-parallel-resample we have already touched upon different parallelization backends.
@@ -412,7 +412,7 @@ To estimate the total runtime, a subset of the benchmark is usually executed and
 ### HPC Basics {#sec-hpc-basics}
 
 An HPC cluster is a collection of interconnected computers or servers providing computational power beyond what a single computer can achieve.
-They are used for solving complex problems in chemistry, physics, engineering, machine learning and other fields that require a large amount of computational resources.
+They are used for solving complex problems in chemistry, physics, engineering, ML and other fields that require a large amount of computational resources.
 An HPC cluster typically consists of multiple compute nodes, each with multiple CPU/GPU cores, memory, and local storage.
 These nodes are connected together by a high-speed network and network file system which enables the nodes to communicate and work together on a given task.
 These clusters are also designed to run parallel applications that can be split into smaller tasks and distributed across multiple compute nodes to be executed simultaneously.
@@ -976,7 +976,7 @@ Our null hypothesis is that a single regression tree performs equally well than 
 1. Load the OpenML collection with ID `r link("269", "https://www.openml.org/search?type=study&study_type=task&id=269")`. It contains regression tasks from the AutoML benchmark [@amlb2022].
 2. Find all tasks with less than 4000 observations and convert them to mlr3 tasks.
 3. Create an experimental design that compares the random forest in `r ref_pkg("ranger")` with the regression tree from `r ref_pkg("rpart")` on those tasks.
-   You can use 3-fold cross-validation instead of the OpenML resamplings to save time.
+   You can use 3-fold CV instead of the OpenML resamplings to save time.
 
 ### Executing the Experiments using batchtools {.unnumbered .unlisted}
 

--- a/book/large_benchmarking.qmd
+++ b/book/large_benchmarking.qmd
@@ -417,7 +417,7 @@ An HPC cluster typically consists of multiple compute nodes, each with multiple 
 These nodes are connected together by a high-speed network and network file system which enables the nodes to communicate and work together on a given task.
 These clusters are also designed to run parallel applications that can be split into smaller tasks and distributed across multiple compute nodes to be executed simultaneously.
 We will leverage this capacity to parallelize the execution of the benchmark experiment.
-The most important difference between such a cluster and a personal computer (PC), is that the nodes cannot be accessed directly, but instead computational jobs are queued by a `r index("scheduling system")` like `r link("https://slurm.schedmd.com", "Slurm")` (Simple Linux Utility for Resource Management).
+The most important difference between such a cluster and a personal computer, is that the nodes cannot be accessed directly, but instead computational jobs are queued by a `r index("scheduling system")` like `r link("https://slurm.schedmd.com", "Slurm")` (Simple Linux Utility for Resource Management).
 A scheduling system is a software tool that orchestrates the allocation of computing resources to users or applications on the cluster.
 It ensures that multiple users and applications can access the resources of the cluster in a fair and efficient manner, and also helps to maximize the utilization of the computing resources.
 

--- a/book/non_sequential_pipelines_and_tuning.qmd
+++ b/book/non_sequential_pipelines_and_tuning.qmd
@@ -268,7 +268,7 @@ Just as for bagging, it is possible to create a stacking pipeline using `ppl()`,
 Here, the choice is to train an ensemble of different models, the outputs of which are then used as features for a logistic regression model.
 
 To limit overfitting, we must create the stacking features from predictions made for data that was not in the training sample.
-Therefore, a `r ref("PipeOpLearnerCV", "po(\"learner_cv\")")` is used, which performs cross-validation on the training data, fitting a model in each fold.
+Therefore, a `r ref("PipeOpLearnerCV", "po(\"learner_cv\")")` is used, which performs CV on the training data, fitting a model in each fold.
 Each of the models is then used to predict on the out-of-fold data.
 As a result, we obtain predictions for every data point in our input data.
 
@@ -277,7 +277,7 @@ These are the "level 0" learners.
 Besides the `r ref("LearnerClassifRpart", "lrn(\"classif.rpart\")")` that we have already seen, we also use the k-nearest-neighbor (KNN) learner `r ref("LearnerClassifKKNN", "lrn(\"classif.kknn\")")` and the LASSO learner `r ref("LearnerClassifCVGlmnet", "lrn(\"classif.cv_glmnet\")")`.
 We set the `predict_type` to `"prob"` for all learners, so that they produce class probabilities instead of hard class predictions.
 We have also set the `kernel` hyperparameter of the KNN learner to `"rectangular"`, which is the simplest distance kernel.
-Note that the "`cv`" in the name of the LASSO learner indicates that it performs cross-validation to select the regularization parameter -- it happens independently of the cross-validation performed by `r ref("PipeOpLearnerCV", "po(\"learner_cv\")")`.
+Note that the "`cv`" in the name of the LASSO learner indicates that it performs CV to select the regularization parameter -- it happens independently of the CV performed by `r ref("PipeOpLearnerCV", "po(\"learner_cv\")")`.
 
 ```{r 05-pipelines-non-sequential-015, eval = TRUE}
 learner_rpart = lrn("classif.rpart", predict_type = "prob")
@@ -395,7 +395,7 @@ head(mnist_task$feature_names)
 ### Tuning Combined Spaces {#sec-pipelines-combined}
 
 Instead of using deep learning, we will use the much simpler KNN learner `r ref("LearnerClassifKKNN", "lrn(\"classif.kknn\")")`, again with the simple `"rectangular"` distance kernel.
-We investigate if doing a principal component analysis using `r ref("PipeOpPCA", "po(\"pca\")")`, and selecting the highest variance components using the `rank.` hyperparameter, can improve performance.
+We investigate if doing a PCA using `r ref("PipeOpPCA", "po(\"pca\")")`, and selecting the highest variance components using the `rank.` hyperparameter, can improve performance.
 Because the `k` hyperparameter of the KNN learner also needs to be found, we need to tune it simultaneously.
 
 First, we need to define the Graph that we are tuning.

--- a/book/non_sequential_pipelines_and_tuning.qmd
+++ b/book/non_sequential_pipelines_and_tuning.qmd
@@ -371,7 +371,7 @@ Tuning machine learning models with `r mlr3pipelines` can be considered at vario
 The first level is not much different from tuning individual learners, as described in @sec-optimization.
 The only thing to watch out for here is that a learner's hyperparameter names are prefixed with its ID, as shown in @sec-pipelines-hyperparameters.
 The second level is demonstrated in the following @sec-pipelines-combined.
-The third level is also referred to as the "Combined Algorithm Selection and Hyperparameter optimization" (also known as CASH) [@Thornton2013].
+The third level is also referred to as the "Combined Algorithm Selection and Hyperparameter optimization" (CASH) [@Thornton2013].
 This is demonstrated in @sec-pipelines-branch, which shows how to use alternative path branching.
 An alternative way of implementing it is to use `r ref("PipeOpProxy", "po(\"proxy\")")`, demonstrated in the (advanced) @sec-pipelines-proxy.
 

--- a/book/non_sequential_pipelines_and_tuning.qmd
+++ b/book/non_sequential_pipelines_and_tuning.qmd
@@ -362,7 +362,7 @@ On a higher level, we can then combine those predictions in order to form a very
 Having as many options for preprocessing as provided by `r mlr3pipelines` has many benefits, but it also comes with a drawback:
 It enlarges the space of possible hyperparameter configurations considerably.
 Not only do preprocessing operations bring their own hyperparameter settings, but the decisions on whether to do preprocessing, and which preprocessing operation to perform, also need to be made.
-Tuning ML models with `r mlr3pipelines` can be considered at various levels of complexity:
+Tuning machine learning models with `r mlr3pipelines` can be considered at various levels of complexity:
 
 1. Tuning the hyperparameters of a learner or a PipeOp individually when it is part of a Graph.
 2. Jointly tuning the hyperparameters of both learner and its preprocessing operations.
@@ -371,7 +371,7 @@ Tuning ML models with `r mlr3pipelines` can be considered at various levels of c
 The first level is not much different from tuning individual learners, as described in @sec-optimization.
 The only thing to watch out for here is that a learner's hyperparameter names are prefixed with its ID, as shown in @sec-pipelines-hyperparameters.
 The second level is demonstrated in the following @sec-pipelines-combined.
-The third level is also referred to as the "Combined Algorithm Selection and Hyperparameter optimization" (CASH) [@Thornton2013].
+The third level is also referred to as the "Combined Algorithm Selection and Hyperparameter optimization" (also known as CASH) [@Thornton2013].
 This is demonstrated in @sec-pipelines-branch, which shows how to use alternative path branching.
 An alternative way of implementing it is to use `r ref("PipeOpProxy", "po(\"proxy\")")`, demonstrated in the (advanced) @sec-pipelines-proxy.
 
@@ -394,7 +394,7 @@ head(mnist_task$feature_names)
 
 ### Tuning Combined Spaces {#sec-pipelines-combined}
 
-Instead of using deep learning, we will use the much simpler k-nearest-neighbor (KNN) learner `r ref("LearnerClassifKKNN", "lrn(\"classif.kknn\")")`, again with the simple `"rectangular"` distance kernel.
+Instead of using deep learning, we will use the much simpler KNN learner `r ref("LearnerClassifKKNN", "lrn(\"classif.kknn\")")`, again with the simple `"rectangular"` distance kernel.
 We investigate if doing a principal component analysis using `r ref("PipeOpPCA", "po(\"pca\")")`, and selecting the highest variance components using the `rank.` hyperparameter, can improve performance.
 Because the `k` hyperparameter of the KNN learner also needs to be found, we need to tune it simultaneously.
 

--- a/book/optimization.qmd
+++ b/book/optimization.qmd
@@ -18,8 +18,8 @@ HPO closely relates to model evaluation (@sec-performance) as the objective is t
 Broadly speaking, we could think of finding the optimal model configuration in the same way as selecting a model from a benchmark experiment, where in this case each model in the experiment is the same algorithm but with different hyperparameter configurations.
 For example, we could benchmark three `r index("support vector machines")` (SVMs) with three difference `cost` values.
 However, human trial-and-error is time-consuming, subjective and often biased, error-prone, and computationally inefficient.
-Instead, many sophisticated HPO methods (@sec-tuner) (or '`r index('tuners')`') have been developed over the past few decades for robust and efficient HPO.
-Besides simple approaches such as a `r index('random search')` or `r index('grid search')`, most HPO methods employ iterative techniques that propose different configurations over time, often exhibiting adaptive behavior guided towards potentially optimal hyperparameter configurations.
+Instead, many sophisticated hyperparameter optimization methods (@sec-tuner) (or '`r index('tuners')`') have been developed over the past few decades for robust and efficient HPO.
+Besides simple approaches such as a `r index('random search')` or `r index('grid search')`, most hyperparameter optimization methods employ iterative techniques that propose different configurations over time, often exhibiting adaptive behavior guided towards potentially optimal hyperparameter configurations.
 These methods continually propose new configurations until a termination criterion is met, at which point the optimal configuration is returned.
 This iterative approach is depicted in a typical optimization loop as shown in Figure (@fig-optimization-loop).
 For more general details on HPO and more theoretical background, we recommend @hpo_practical and @hpo_automl.
@@ -111,7 +111,7 @@ Finally, any of these terminators can be freely combined with the `trm("combo")`
 ### Tuning Instance with `ti` {#sec-tuning-instance}
 
 The tuning instance collects together the tuner-agnostic information required to optimize a model, i.e., all information about the tuning process, except for the tuning algorithm itself.
-This includes the task to tune over, the learner to tune, the resampling method and measure used to analytically compare HPO configurations, and the terminator to determine when the measure has been optimized 'enough'.
+This includes the task to tune over, the learner to tune, the resampling method and measure used to analytically compare hyperparameter optimization configurations, and the terminator to determine when the measure has been optimized 'enough'.
 
 A `r index("tuning instance", aside = TRUE)` can be constructed manually with the `r ref("ti()")` function, or automated (@sec-simplified-tuning) with the `r ref("tune()")` function.
 We cover the manual approach first as this allows finer control of tuning and a more nuanced discussion about the design and use of `r mlr3tuning`.
@@ -190,7 +190,7 @@ Racing algorithms work by iteratively discarding configurations that show poor p
 Iterative Racing [@lopez2016] starts by 'racing' down an initial population of randomly sampled configurations from a parametrized density and then uses the surviving configurations of the race to stochastically update the density of the subsequent race to focus on promising regions of the search space, and so on.
 
 Multi-fidelity HPO is an adaptive method that leverages the predictive power of computationally cheap lower fidelity evaluations (i.e., poorer quality predictions such as those arising from neural networks with a small number of epochs) to improve the overall optimization efficiency.
-This concept is used in Hyperband (@sec-hyperband), a popular multi-fidelity HPO algorithm that dynamically allocates increasingly more resources to promising configurations and terminates low-performing ones.
+This concept is used in Hyperband (@sec-hyperband), a popular multi-fidelity hyperparameter optimization algorithm that dynamically allocates increasingly more resources to promising configurations and terminates low-performing ones.
 Hyperband tends to outperform random search as the optimization budget is used much more efficiently.
 
 Other implemented algorithms for numeric search spaces are Generalized Simulated Annealing [@xiang2013; @tsallis1996] and various nonlinear optimization algorithms.
@@ -210,7 +210,7 @@ When choosing between evolutionary strategies and Bayesian optimization, the cos
 If hyperparameter configurations can be evaluated quickly, evolutionary strategies often find good configurations within a reasonable time frame.
 On the other hand, if model evaluations are time-consuming and the optimization budget is limited, Bayesian optimization is usually preferred.
 
-Finally, in cases where the HPO problem involves a meaningful fidelity parameter (e.g., number of epochs, number of trees, number of boosting rounds) and optimization budget needs to be spent efficiently, multi-fidelity HPO algorithms like Hyperband may be worth considering.
+Finally, in cases where the hyperparameter optimization problem involves a meaningful fidelity parameter (e.g., number of epochs, number of trees, number of boosting rounds) and optimization budget needs to be spent efficiently, multi-fidelity hyperparameter optimization algorithms like Hyperband may be worth considering.
 For further details on different tuners and practical recommendations, we refer to @hpo_practical.
 
 ::: {.callout-tip}
@@ -243,7 +243,7 @@ Whilst changing the control parameters of the tuner can improve optimal performa
 #### Triggering the tuning process {.unnumbered .unlisted}
 
 Now that we have all our components, we can start the tuning process.
-To do this we simply pass the constructed `r ref("TuningInstanceSingleCrit")` to the `$optimize()` method of the initialized `r ref("Tuner")`, which triggers the HPO loop (@fig-optimization-loop).
+To do this we simply pass the constructed `r ref("TuningInstanceSingleCrit")` to the `$optimize()` method of the initialized `r ref("Tuner")`, which triggers the hyperparameter optimization loop (@fig-optimization-loop).
 
 ```{r optimization-010}
 tuner$optimize(instance)

--- a/book/optimization.qmd
+++ b/book/optimization.qmd
@@ -118,7 +118,7 @@ We cover the manual approach first as this allows finer control of tuning and a 
 
 Continuing our example, we will construct a `r index("single-objective")` tuning problem (i.e., tuning over *one* measure) by using the `r ref("ti()")` function to create a `r ref("TuningInstanceSingleCrit")`, we will return to `r index('multi-objective')` tuning in @sec-multi-metrics-tuning.
 
-For this example we will use three-fold cross-validation and optimize the classification error measure.
+For this example we will use three-fold CV and optimize the classification error measure.
 Note that in the next section we will continue our example with a grid search tuner, so we select `trm("none")`.
 
 ```{r optimization-007}
@@ -172,7 +172,7 @@ Due to their simplicity, both grid search and random search can handle mixed sea
 
 #### Adaptive algorithms {.unnumbered .unlisted}
 
-Adaptive algorithms learn from previously evaluated configurations to find good configurations more quickly, examples in `mlr3` include Bayesian optimization (also called model-based optimization\index{MBO}), Covariance Matrix Adaptation Evolution Strategy (CMA-ES), Iterative Racing, and Hyperband.
+Adaptive algorithms learn from previously evaluated configurations to find good configurations more quickly, examples in `mlr3` include Bayesian optimization (also called model-based optimization), Covariance Matrix Adaptation Evolution Strategy (CMA-ES), Iterative Racing, and Hyperband.
 
 <!-- FIXME - It might make sense to shorten this once I've read MBO if there's a lot of duplication -->
 Bayesian optimization (@sec-bayesian-optimization) [e.g., @Snoek2012] describes a family of iterative optimization algorithms that use a surrogate model to approximate the unknown function that is to be optimized -- in HPO the mapping from a hyperparameter configuration to the estimated generalization performance.
@@ -194,7 +194,7 @@ This concept is used in Hyperband (@sec-hyperband), a popular multi-fidelity hyp
 Hyperband tends to outperform random search as the optimization budget is used much more efficiently.
 
 Other implemented algorithms for numeric search spaces are Generalized Simulated Annealing [@xiang2013; @tsallis1996] and various nonlinear optimization algorithms.
-These can be useful if evaluations are rather cheap as they require more function evaluations and are therefore less sample efficient than other sophisticated methods (e.g., MBO) but are more commonly used for general, numeric black-box optimization.
+These can be useful if evaluations are rather cheap as they require more function evaluations and are therefore less sample efficient than other sophisticated methods (e.g., bayesian optimization) but are more commonly used for general, numeric black-box optimization.
 
 #### Choosing strategies {.unnumbered .unlisted}
 
@@ -463,8 +463,8 @@ For more details and a formal introduction to nested resampling the reader is re
 
 ```{r optimization-024}
 #| label: fig-nested-resampling
-#| fig-cap: An illustration of nested resampling. The large blocks represent 3-fold cross-validation for the outer resampling for model evaluation and the small blocks represent 4-fold cross-validation for the inner resampling for HPO. The light blue blocks are the training sets and the dark blue blocks are the test sets.
-#| fig-alt: The image shows three rows of large blocks representing three-fold cross-validation for the outer resampling. Below the blocks are four further rows of small blocks representing four-fold cross-validation for the inner resampling. The training sets are represented in light blue and the test sets in dark blue.
+#| fig-cap: An illustration of nested resampling. The large blocks represent 3-fold CV for the outer resampling for model evaluation and the small blocks represent 4-fold CV for the inner resampling for HPO. The light blue blocks are the training sets and the dark blue blocks are the test sets.
+#| fig-alt: The image shows three rows of large blocks representing three-fold CV for the outer resampling. Below the blocks are four further rows of small blocks representing four-fold CV for the inner resampling. The training sets are represented in light blue and the test sets in dark blue.
 #| echo: false
 
 knitr::include_graphics("Figures/nested_resampling.png")
@@ -472,8 +472,8 @@ knitr::include_graphics("Figures/nested_resampling.png")
 
 @fig-nested-resampling represents the following example of nested resampling:
 
-1. `r index("Outer resampling")` -- Instantiate 3-fold cross-validation to create different testing and training datasets.
-2. `r index("Inner resampling")` -- Within the outer training data instantiate 4-fold cross-validation to create different inner testing and training datasets.
+1. `r index("Outer resampling")` -- Instantiate 3-fold CV to create different testing and training datasets.
+2. `r index("Inner resampling")` -- Within the outer training data instantiate 4-fold CV to create different inner testing and training datasets.
 3. HPO -- Tune the hyperparameters on the outer training set (large, light blue blocks) using the inner data splits.
 4. Training -- Fit the learner on the outer training dataset using the optimal hyperparameter configuration obtained from the inner resampling (small blocks).
 5. Evaluation -- Evaluate the performance of the learner on the outer testing data (large, dark blue block).
@@ -496,7 +496,7 @@ If you are interested in identifying optimal configurations, then  use `tune`/`t
 ### Resampling an `AutoTuner`
 
 Whilst the theory of nested resampling may seem complicated, it is all automated in `r mlr3tuning` by simply passing an `AutoTuner` to `r ref("resample()")` or `r ref("benchmark()")`.
-Continuing with our previous example, we will use the auto-tuner to resample a support vector classifier with 3-fold cross-validation in the outer-resampling and 4-fold cross-validation in the inner resampling.
+Continuing with our previous example, we will use the auto-tuner to resample a support vector classifier with 3-fold CV in the outer-resampling and 4-fold CV in the inner resampling.
 
 ```{r optimization-025}
 at = auto_tuner(
@@ -512,7 +512,7 @@ rr
 ```
 
 Note that we set `store_models = TRUE` so that the `r ref("AutoTuner")` models (fitted on the outer training data) are stored, which also enables investigation of the inner tuning instances.
-Whilst we used K-fold cross-validation for both the inner and outer resampling strategy, you could use different resampling strategies (@sec-resampling) and also different parallelization methods (@sec-nested-resampling-parallelization).
+Whilst we used K-fold CV for both the inner and outer resampling strategy, you could use different resampling strategies (@sec-resampling) and also different parallelization methods (@sec-nested-resampling-parallelization).
 
 The estimated performance of a tuned model is reported as the aggregated performance of all outer resampling iterations, which is an unbiased estimate of future model performance.
 
@@ -939,9 +939,9 @@ We have a few practical examples of tuning that may be useful for more specific 
 
 1. Tune the `mtry`, `sample.fraction`, ` num.trees` hyperparameters of a random forest model (`regr.ranger`) on the `mtcars` task.
 Use a simple random search with 50 evaluations and select a suitable batch size.
-Evaluate with a 3-fold cross-validation and the root mean squared error.
+Evaluate with a 3-fold CV and the root mean squared error.
 1. Evaluate the performance of the model created in Question 1 with nested resampling.
-Use a holdout validation for the inner resampling and a 3-fold cross-validation for the outer resampling.
+Use a holdout validation for the inner resampling and a 3-fold CV for the outer resampling.
 Print the unbiased performance estimate of the model.
 1. Tune and benchmark an XGBoost model against a logistic regression and determine which has the best Brier score.
 Use mlr3tuningspaces and nested resampling.

--- a/book/optimization.qmd
+++ b/book/optimization.qmd
@@ -454,7 +454,7 @@ We could also pass the `r ref("AutoTuner")` to `r ref("resample()")` and `r ref(
 
 ## Nested Resampling {#sec-nested-resampling}
 
-Hyperparameter optimization requires additional resampling to reduce bias when estimating performance of the model.
+HPO requires additional resampling to reduce bias when estimating performance of the model.
 If the same data is used for determining the optimal configuration and the evaluation of the resulting model itself, the actual performance estimate of the model might be severely biased [@Simon2007].
 This is analogous to `r index("optimism of the training error")` described in @james2013introduction, which occurs when training error is taken as an estimate of out-of-sample performance.
 

--- a/book/optimization.qmd
+++ b/book/optimization.qmd
@@ -5,7 +5,7 @@
 `r chapter = "Hyperparameter Optimization"`
 `r authors(chapter)`
 
-Machine learning algorithms usually include `r index("parameters")` and `r index("hyperparameters", aside = TRUE)`.
+ML algorithms usually include `r index("parameters")` and `r index("hyperparameters", aside = TRUE)`.
 Parameters are the model coefficients or weights or other information that are determined by the learning algorithm based on the training data.
 In contrast, hyperparameters, are configured by the user and determine how the model will fit its parameters, i.e., how the model is built.
 Examples include setting the number of trees in a random forest, penalty settings in support vector machines, or the learning rate in a neural network.
@@ -860,7 +860,7 @@ lrn("classif.svm",
 {{< include _optional.qmd >}}
 
 Selected search spaces can require a lot of background knowledge or expertise.
-The package `r ref_pkg("mlr3tuningspaces")` tries to make HPO more accessible by providing implementations of published search spaces for many popular machine learning algorithms, the hope is that these search spaces are applicable to a wide range of datasets.
+The package `r ref_pkg("mlr3tuningspaces")` tries to make HPO more accessible by providing implementations of published search spaces for many popular ML algorithms, the hope is that these search spaces are applicable to a wide range of datasets.
 The search spaces are stored in the dictionary `r ref("mlr_tuning_spaces")`.
 
 ```{r optimization-056,message=FALSE}

--- a/book/optimization.qmd
+++ b/book/optimization.qmd
@@ -5,14 +5,14 @@
 `r chapter = "Hyperparameter Optimization"`
 `r authors(chapter)`
 
-ML algorithms usually include `r index("parameters")` and `r index("hyperparameters", aside = TRUE)`.
+Machine learning algorithms usually include `r index("parameters")` and `r index("hyperparameters", aside = TRUE)`.
 Parameters are the model coefficients or weights or other information that are determined by the learning algorithm based on the training data.
 In contrast, hyperparameters, are configured by the user and determine how the model will fit its parameters, i.e., how the model is built.
 Examples include setting the number of trees in a random forest, penalty settings in support vector machines, or the learning rate in a neural network.
 
-The goal of `r index("hyperparameter optimization", aside = TRUE)` (@sec-model-tuning) or model `r index("tuning")` is to find the optimal configuration of hyperparameters of an ML algorithm for a given task.
+The goal of `r index("hyperparameter optimization", aside = TRUE)` (HPO, see @sec-model-tuning) or model `r index("tuning")` is to find the optimal configuration of hyperparameters of a machine learning algorithm for a given task.
 There is no closed-form mathematical representation (nor analytic gradient information) for model agnostic HPO.
-Instead, we follow a black-box optimization approach: an ML algorithm is configured with values chosen for one or more hyperparameters, this algorithm is then evaluated (using a resampling method) and its performance is measured.
+Instead, we follow a black-box optimization approach: a machine learning algorithm is configured with values chosen for one or more hyperparameters, this algorithm is then evaluated (using a resampling method) and its performance is measured.
 This process is repeated with multiple configurations and finally the configuration with the best performance is selected.
 HPO closely relates to model evaluation (@sec-performance) as the objective is to find a hyperparameter configuration that optimizes the generalization performance.
 Broadly speaking, we could think of finding the optimal model configuration in the same way as selecting a model from a benchmark experiment, where in this case each model in the experiment is the same algorithm but with different hyperparameter configurations.
@@ -860,7 +860,7 @@ lrn("classif.svm",
 {{< include _optional.qmd >}}
 
 Selected search spaces can require a lot of background knowledge or expertise.
-The package `r ref_pkg("mlr3tuningspaces")` tries to make HPO more accessible by providing implementations of published search spaces for many popular ML algorithms, the hope is that these search spaces are applicable to a wide range of datasets.
+The package `r ref_pkg("mlr3tuningspaces")` tries to make HPO more accessible by providing implementations of published search spaces for many popular machine learning algorithms, the hope is that these search spaces are applicable to a wide range of datasets.
 The search spaces are stored in the dictionary `r ref("mlr_tuning_spaces")`.
 
 ```{r optimization-056,message=FALSE}

--- a/book/performance.qmd
+++ b/book/performance.qmd
@@ -107,7 +107,7 @@ The $k$ models are trained on training data consisting of $k-1$ of the folds, wi
 The $k$ performance estimates resulting from each fold are aggregated to obtain a more reliable performance estimate (@hastie2001).
 Cross-validation guarantees that each observation will be used in one of the test sets throughout the procedure, making efficient use of the available data for performance estimation.
 Common values for $k$ are 5 and 10, meaning each training will consist of 4/5 or 9/10 of the original data respectively.
-Several variations of cross-validation exist, including repeated $k$-fold cross-validation [Repeated $k$-fold cross-validation]{.aside}\index{resampling!repeated k-fold cross-validation} where the $k$-fold process is repeated multiple times, and `r index('leave-one-out cross-validation', aside = TRUE)` (LOO-CV) where the number of folds is equal to the number of observations, leading to the test set in each fold consisting of exactly one observation.
+Several variations of CV exist, including repeated $k$-fold cross-validation [Repeated $k$-fold cross-validation]{.aside}\index{resampling!repeated k-fold cross-validation} where the $k$-fold process is repeated multiple times, and `r index('leave-one-out cross-validation', aside = TRUE)` (LOO-CV) where the number of folds is equal to the number of observations, leading to the test set in each fold consisting of exactly one observation.
 LOO-CV sounds reduces variance in the performance estimate but is computationally very expensive due to the need to fit $N$ models.
 For linear or polynomial regression models, LOO-CV with mean squared error as the performance measure can be computed efficiently via a closed-form formula without the need to fit $N$ models, yet this does not apply in the general case (see @james2013introduction).
 Furthermore, LOO-CV is also problematic in imbalanced binary classification tasks as concepts such as stratification (see @sec-strat-group) cannot be applied to LOO-CV.
@@ -115,7 +115,7 @@ Furthermore, LOO-CV is also problematic in imbalanced binary classification task
 `r define("Subsampling")` and `r define("bootstrapping")` are two related resampling strategies.
 Subsampling randomly selects a given ratio (4/5 and 9/10 are common) of the data for the training dataset where each observation in the dataset is drawn *without replacement* from the original dataset.
 The model is trained on this data and then tested on the remaining data, and this process is repeated $k$ times.
-This differs from $k$-fold cross-validation as the subsets of training/test data between iterations are not related and each is drawn independently from one another, which means that, across iterations, observations could occur in more than one testing dataset (but only once per dataset).
+This differs from $k$-fold CV as the subsets of training/test data between iterations are not related and each is drawn independently from one another, which means that, across iterations, observations could occur in more than one testing dataset (but only once per dataset).
 Bootstrapping follows the same process as subsampling but data is drawn *with replacement* from the original dataset, this means an observation could be selected multiple times (and thus duplicated) in the training data (but never more than once per test dataset).
 This means that bootstrapping can result in training sets of the same size as the original data, but at the cost of repeating some observations.
 On average, $1 - e^{-1} \approx 63.2\%$ of the data points will be contained in the training set during bootstrapping, referred to as "in-bag" samples (the other 36.8% are known as "out-of-bag" samples).
@@ -125,7 +125,7 @@ Note that terminology regarding resampling strategies is not consistent across t
 
 The choice of the resampling strategy usually depends on the specific task at hand and the goals of the performance assessment, but some rules of thumb are available.
 If the available data is fairly small ($N \leq 500$), repeated cross-validation with a large number of repetitions can be used to keep the variance of the performance estimates low (10 folds and 10 repetitions is a good place to start).
-For the $500 \leq N \leq 50000$ range, 5- to 10-fold cross-validation is generally recommended.
+For the $500 \leq N \leq 50000$ range, 5- to 10-fold CV is generally recommended.
 In general, the larger the dataset, the fewer splits are required, yet sample-size issues can still occur, e.g., due to imbalanced data.
 Additional recommendations are given by @hpo_practical, which focuses on the model optimization aspect covered in @sec-optimization.
 Properties and pitfalls of different resampling techniques, some of which we have summarized here, have been widely studied and discussed in the literature, e.g., @molinaro2005prediction, @kim2009estimating, and @bischl2012resampling.
@@ -172,7 +172,7 @@ rcv25 = rsmp("repeated_cv", repeats = 2, folds = 5)
 
 When a `r ref("Resampling")` object is constructed, it is simply a definition for how the data splitting process will be performed on the task when running the resampling strategy.
 However, it is possible to manually instantiate a resampling strategy, i.e., generate all train-test splits, by calling the `$instantiate()`\index{\$instantiate()}[`$instantiate()`]{.aside} method on a given task.
-So carrying on our `penguins` example we can instantiate the 3-fold cross-validation object and then view the row indices of the data selected for training and testing each fold using `$train_set()` and `$test_set()` respectively:
+So carrying on our `penguins` example we can instantiate the 3-fold CV object and then view the row indices of the data selected for training and testing each fold using `$train_set()` and `$test_set()` respectively:
 
 ```{r performance-012}
 cv3$instantiate(task)
@@ -339,7 +339,7 @@ resample(task, learner, resampling)$prediction()
 
 A custom cross-validation strategy can more efficiently be constructed with `rsmp("custom_cv")`.
 In this case, we now have to specify either a custom `factor` variable or a `factor` column from the data to determine the folds.
-In the example below, we use a smaller version of the `penguins` task and instantiate a custom 2-fold cross-validation strategy using a `factor` variable called `folds` where the first and third rows are used as the test set in Fold 1, and the second and fourth rows are used as the test set in Fold 2:
+In the example below, we use a smaller version of the `penguins` task and instantiate a custom 2-fold CV strategy using a `factor` variable called `folds` where the first and third rows are used as the test set in Fold 1, and the second and fourth rows are used as the test set in Fold 2:
 
 ```{r performance-025}
 task_small = tsk("penguins")$filter(c(1, 100, 200, 300))
@@ -409,7 +409,7 @@ The `penguins` task displays imbalance in the `species` column, as can be seen i
 prop.table(table(task$data(cols = "species")))
 ```
 
-Without specifying a `"stratum"` column role, the `species` column may have quite different class distributions across the training and test sets of a k-fold cross-validation strategy, as can be seen in the example below.
+Without specifying a `"stratum"` column role, the `species` column may have quite different class distributions across the training and test sets of a k-fold CV strategy, as can be seen in the example below.
 
 ```{r performance-030}
 cv10 = rsmp("cv", folds = 10)
@@ -843,13 +843,13 @@ Use 100 replicates and an a sampling ratio of 80%.
 Calculate the MSE for each iteration and visualize the result.
 Finally, calculate the aggregated performance score.
 
-2. Use the `spam` task and 5-fold cross-validation to benchmark Random Forest (`classif.ranger`), Logistic Regression (`classif.log_reg`), and XGBoost (`classif.xgboost`) with regards to AUC.
+2. Use the `spam` task and 5-fold CV to benchmark Random Forest (`classif.ranger`), Logistic Regression (`classif.log_reg`), and XGBoost (`classif.xgboost`) with regards to AUC.
 Which learner appears to do best? How confident are you in your conclusion?
 How would you improve upon this?
 
 3. A colleague claims to have achieved a 93.1% classification accuracy using the `classif.rpart` learner on the `penguins_simple` task.
 You want to reproduce their results and ask them about their resampling strategy.
-They said they used a custom 3-fold cross-validation with folds assigned as `factor(task$row_ids %% 3)`.
+They said they used a custom 3-fold CV with folds assigned as `factor(task$row_ids %% 3)`.
 See if you can reproduce their results.
 
 ::: {.content-visible when-format="html"}

--- a/book/performance.qmd
+++ b/book/performance.qmd
@@ -6,7 +6,7 @@
 `r authors(chapter)`
 
 In supervised machine learning, a model can only be deployed in practice if it generalizes well to new, unseen data, that is if it has a good `r index("generalization performance", aside = TRUE)`.
-Accurate estimation of the generalization performance is crucial for many aspects of machine learning application and research -- whether we want to fairly compare a novel algorithm with established ones, or to find the best algorithm for a particular task.
+Accurate estimation of the generalization performance is crucial for many aspects of ML application and research -- whether we want to fairly compare a novel algorithm with established ones, or to find the best algorithm for a particular task.
 The concept of `r index("performance estimation")` provides information on how well a model will generalize to new data and plays an important role in the context of model comparison ( @sec-benchmarking), model selection, and hyperparameter tuning (@sec-optimization).
 
 Assessing the generalization performance of a model begins with selecting a `r index("performance measure")` that is appropriate for our given task and evaluation goal.

--- a/book/performance.qmd
+++ b/book/performance.qmd
@@ -6,7 +6,7 @@
 `r authors(chapter)`
 
 In supervised machine learning, a model can only be deployed in practice if it generalizes well to new, unseen data, that is if it has a good `r index("generalization performance", aside = TRUE)`.
-Accurate estimation of the generalization performance is crucial for many aspects of ML application and research -- whether we want to fairly compare a novel algorithm with established ones, or to find the best algorithm for a particular task.
+Accurate estimation of the generalization performance is crucial for many aspects of machine learning application and research -- whether we want to fairly compare a novel algorithm with established ones, or to find the best algorithm for a particular task.
 The concept of `r index("performance estimation")` provides information on how well a model will generalize to new data and plays an important role in the context of model comparison ( @sec-benchmarking), model selection, and hyperparameter tuning (@sec-optimization).
 
 Assessing the generalization performance of a model begins with selecting a `r index("performance measure")` that is appropriate for our given task and evaluation goal.
@@ -109,7 +109,7 @@ Cross-validation guarantees that each observation will be used in one of the tes
 Common values for $k$ are 5 and 10, meaning each training will consist of 4/5 or 9/10 of the original data respectively.
 Several variations of cross-validation exist, including repeated $k$-fold cross-validation [Repeated $k$-fold cross-validation]{.aside}\index{resampling!repeated k-fold cross-validation} where the $k$-fold process is repeated multiple times, and `r index('leave-one-out cross-validation', aside = TRUE)` (LOO-CV) where the number of folds is equal to the number of observations, leading to the test set in each fold consisting of exactly one observation.
 LOO-CV sounds reduces variance in the performance estimate but is computationally very expensive due to the need to fit $N$ models.
-For linear or polynomial regression models, LOO-CV with mean squared error (MSE) as the performance measure can be computed efficiently via a closed-form formula without the need to fit $N$ models, yet this does not apply in the general case (see @james2013introduction).
+For linear or polynomial regression models, LOO-CV with mean squared error as the performance measure can be computed efficiently via a closed-form formula without the need to fit $N$ models, yet this does not apply in the general case (see @james2013introduction).
 Furthermore, LOO-CV is also problematic in imbalanced binary classification tasks as concepts such as stratification (see @sec-strat-group) cannot be applied to LOO-CV.
 
 `r define("Subsampling")` and `r define("bootstrapping")` are two related resampling strategies.
@@ -739,7 +739,7 @@ For example, we can use the previous `r ref("Prediction")` object to compute all
 autoplot(pred, type = "roc")
 ```
 
-A natural performance measure that can be derived from the ROC curve is the `r index('area under the curve (AUC)', aside = TRUE)`, implemented in `classif.auc`.
+A natural performance measure that can be derived from the ROC curve is the `r index('area under the curve', aside = TRUE)` (AUC), implemented in `classif.auc`.
 The AUC can be interpreted as the probability that a randomly chosen positive instance has a higher predicted probability of belonging to the positive class than a randomly chosen negative instance.
 Therefore, higher values (measured between 0 and 1) indicate better performance.
 Random classifiers (such as the featureless baseline) will always have an AUC of 0.5 (see @fig-roc, panel (b)).
@@ -759,7 +759,7 @@ Extensions of ROC analysis for multiclass classifiers exist (see e.g., @hand2001
 Generalizations of the AUC measure to multiclass classification are implemented in `mlr3`, see `msr("classif.mauc_au1p")`.
 :::
 
-We can also plot the `r index('precision-recall (PR) curve', aside = TRUE)` which visualizes the PPV/precision vs. TPR/recall.
+We can also plot the `r index('precision-recall curve', aside = TRUE)` (PRC) which visualizes the PPV/precision vs. TPR/recall.
 The main difference between ROC curves and PR curves is that the number of true-negatives are ignored, which can be useful in imbalanced populations where the positive class is rare and hence the FPR will be low even for random classifier.
 As a result, the ROC curve may not provide a good assessment of the classifier's performance, because it does not capture the high rate of false negatives (i.e., misclassified positive observations).
 See also @davis2006relationship for a detailed discussion about the relationship between the PRC and ROC curves.

--- a/book/performance.qmd
+++ b/book/performance.qmd
@@ -115,7 +115,7 @@ Furthermore, LOO-CV is also problematic in imbalanced binary classification task
 `r define("Subsampling")` and `r define("bootstrapping")` are two related resampling strategies.
 Subsampling randomly selects a given ratio (4/5 and 9/10 are common) of the data for the training dataset where each observation in the dataset is drawn *without replacement* from the original dataset.
 The model is trained on this data and then tested on the remaining data, and this process is repeated $k$ times.
-This differs from $k$-fold CV as the subsets of training/test data between iterations are not related and each is drawn independently from one another, which means that, across iterations, observations could occur in more than one testing dataset (but only once per dataset).
+This differs from $k$-fold cross-validation as the subsets of training/test data between iterations are not related and each is drawn independently from one another, which means that, across iterations, observations could occur in more than one testing dataset (but only once per dataset).
 Bootstrapping follows the same process as subsampling but data is drawn *with replacement* from the original dataset, this means an observation could be selected multiple times (and thus duplicated) in the training data (but never more than once per test dataset).
 This means that bootstrapping can result in training sets of the same size as the original data, but at the cost of repeating some observations.
 On average, $1 - e^{-1} \approx 63.2\%$ of the data points will be contained in the training set during bootstrapping, referred to as "in-bag" samples (the other 36.8% are known as "out-of-bag" samples).
@@ -172,7 +172,7 @@ rcv25 = rsmp("repeated_cv", repeats = 2, folds = 5)
 
 When a `r ref("Resampling")` object is constructed, it is simply a definition for how the data splitting process will be performed on the task when running the resampling strategy.
 However, it is possible to manually instantiate a resampling strategy, i.e., generate all train-test splits, by calling the `$instantiate()`\index{\$instantiate()}[`$instantiate()`]{.aside} method on a given task.
-So carrying on our `penguins` example we can instantiate the 3-fold CV object and then view the row indices of the data selected for training and testing each fold using `$train_set()` and `$test_set()` respectively:
+So carrying on our `penguins` example we can instantiate the 3-fold cross-validation object and then view the row indices of the data selected for training and testing each fold using `$train_set()` and `$test_set()` respectively:
 
 ```{r performance-012}
 cv3$instantiate(task)
@@ -316,7 +316,7 @@ lapply(rr$learners, function(x) x$model$variable.importance)[2:3]
 Sometimes it is necessary to perform resampling with custom splits, e.g., to reproduce results reported in a study with pre-defined folds.
 
 A custom holdout resampling strategy can be constructed using `rsmp("custom")`, where the row indices of the observations used for training and testing must be defined manually when instantiated in a task.
-In the example below, we first construct a custom holdout resampling strategy by manually assigning row indices to the `$train` and `$test` fields, then construct a CV type strategy by passing row indices as list elements:
+In the example below, we first construct a custom holdout resampling strategy by manually assigning row indices to the `$train` and `$test` fields, then construct a cross-validation type strategy by passing row indices as list elements:
 
 ```{r performance-023}
 resampling = rsmp("custom")

--- a/book/preprocessing.qmd
+++ b/book/preprocessing.qmd
@@ -11,12 +11,12 @@ Feature selection, whilst being an important preprocessing method, is covered in
 In this book, preprocessing refers to everything that happens with the *data* before it is used to fit the model, while `r index('postprocessing', aside = TRUE)` encompasses everything that occurs with *predictions* after the model is fitted.
 `r index('Data cleaning', aside = TRUE)`\index{exploratory data analysis|see{Data cleaning}} is an important part of preprocessing that involves the removal of errors, noise, and redundancy in the data; we only consider data cleaning very briefly as it is usually performed outside of `mlr3` on the raw dataset.
 
-Another aspect of preprocessing is `r index('feature engineering', aside = TRUE)`, which covers all other transformations of data before it is fed to the ML model, including the creation of features from possibly unstructured data, such as written text, sequences or images.
+Another aspect of preprocessing is `r index('feature engineering', aside = TRUE)`, which covers all other transformations of data before it is fed to the machine learning model, including the creation of features from possibly unstructured data, such as written text, sequences or images.
 The goal of feature engineering is to prepare the data so that a model can be trained on it, and/or to further improve predictive performance.
 It is important to note that feature engineering helps mostly for simpler algorithms, while highly complex models usually gain less from it and require little data preparation to be trained.
 Common difficulties in data that can be solved with feature engineering include features with (high) skew distributions, high cardinality categorical features, missing observations, high dimensional dimensionality and imbalanced classes in classification tasks.
 Deep learning has shown promising results in automating feature engineering, however its effectiveness depends on the complexity and nature of the data being processed, as well as the specific problem being addressed.
-Typically it is applicable to natural language processing (NLP) and computer vision (CV) problems, while standard tabular data is lacking in structure for deep learning models to extract meaningful features automatically.
+Typically it is applicable to natural language processing and computer vision problems, while standard tabular data is lacking in structure for deep learning models to extract meaningful features automatically.
 Furthermore, different problems require different features to be extracted, and deep learning models may not always be able to identify the most relevant features for a given problem without human guidance.
 Hence, manual feature engineering is often required but with `r mlr3pipelines`, we can simplify the process as much as possible.
 
@@ -92,7 +92,7 @@ baseline_res$aggregate(measure)
 
 We refer to variables as categorical features if they can only take a limited set of values, for example the `Paved_Drive` feature can only take values `Dirt_Gravel`, `Partial_Pavement`, and `Paved`.
 
-Many ML algorithms implementations, such as XGBoost [@chen2016xgboost], cannot handle categorical data and so categorical features must be encoded into numerical variables.
+Many machine learning algorithms implementations, such as XGBoost [@chen2016xgboost], cannot handle categorical data and so categorical features must be encoded into numerical variables.
 
 ```{r preprocessing-010, echo = TRUE, eval = TRUE, message=FALSE, error=TRUE}
 xgboost = lrn("regr.xgboost", nrounds = 100)
@@ -234,7 +234,7 @@ bmr$aggregate(measure = measure)[, .(learner_id, regr.mae)]
 
 Similarly to encoding, we see limited difference in performance between the different imputation strategies.
 
-Many more advanced imputation strategies exist, including model based imputation where ML models are used to predict missing values before passing, and multiple imputation where data is repeatedly resampling and imputed in each sample (e.g., by mean imputation) to attain more robust estimates.
+Many more advanced imputation strategies exist, including model based imputation where machine learning models are used to predict missing values before passing, and multiple imputation where data is repeatedly resampling and imputed in each sample (e.g., by mean imputation) to attain more robust estimates.
 However, these more advanced techniques rarely improve the model substantially and the simple imputation techniques introduced above are usually sufficient [@Poulos2018].
 
 ## Pipeline Robustify
@@ -265,7 +265,7 @@ bmr$combine(bmr_new)
 bmr$aggregate(measure = measure)[, .(learner_id, regr.mae)]
 ```
 
-Robustifying the linear regression results in a model that vastly outperforms the featureless baseline and is competitive when compared to more complex ML models.
+Robustifying the linear regression results in a model that vastly outperforms the featureless baseline and is competitive when compared to more complex machine learning models.
 
 ## Scaling Features and Targets
 
@@ -433,7 +433,7 @@ We have not introduced any new classes here so in @tbl-prepro-api we list the `P
 | `r ref("PipeOpEncode")` | Other factor encoding methods |
 | `r ref("PipeOpMissInd")` | Add an indicator column to track missing data |
 | `r ref("PipeOpImputeHist")` | Impute missing data by sampling from a histogram |
-| `r ref("PipeOpImputeOOR")` | Impute missing data with out-of-range (OOR) values |
+| `r ref("PipeOpImputeOOR")` | Impute missing data with out-of-range values |
 | `r ref("pipeline_robustify")` | Graph with common imputation and encoding methods |
 | `r ref("pipeline_targettrafo")` | Graph to transform target during training and invert transformation during prediction |
 

--- a/book/preprocessing.qmd
+++ b/book/preprocessing.qmd
@@ -5,7 +5,7 @@
 `r chapter = "Preprocessing"`
 `r authors(chapter)`
 
-@sec-pipelines and @sec-pipelines-nonseq provided a technical introduction to `r mlr3pipelines`, this chapter will now demonstrate how to use those pipelines to tackle common problems when `r index('preprocessing')` data for machine learning, including factor encoding, imputation of missing values, feature and target transformations, and feature extraction.
+@sec-pipelines and @sec-pipelines-nonseq provided a technical introduction to `r mlr3pipelines`, this chapter will now demonstrate how to use those pipelines to tackle common problems when `r index('preprocessing')` data for ML, including factor encoding, imputation of missing values, feature and target transformations, and feature extraction.
 Feature selection, whilst being an important preprocessing method, is covered in @sec-feature-selection for a more extensive overview.
 
 In this book, preprocessing refers to everything that happens with the *data* before it is used to fit the model, while `r index('postprocessing', aside = TRUE)` encompasses everything that occurs with *predictions* after the model is fitted.

--- a/book/sequential_pipelines.qmd
+++ b/book/sequential_pipelines.qmd
@@ -22,9 +22,9 @@ options(mlr3oml.cache = here::here("book", "openml", "cache"))
 
 ```
 
-Machine learning (ML) toolkits often try to abstract away the processes inside ML algorithms.
+Machine learning toolkits often try to abstract away the processes inside machine learning algorithms.
 These toolkits provide a layer of abstraction, allowing users to swap one algorithm for another without having to worry about specifics of each algorithm.
-The benefit of using `r ref_pkg("mlr3")`, for example, is that one can use any `r ref("Learner")`, `r ref("Task")`, or `r ref("Resampling")` object and use them for typical ML operations, mostly independently of what algorithms or datasets they represent.
+The benefit of using `r ref_pkg("mlr3")`, for example, is that one can use any `r ref("Learner")`, `r ref("Task")`, or `r ref("Resampling")` object and use them for typical machine learning operations, mostly independently of what algorithms or datasets they represent.
 In the following code snippet, it would be trivial to swap in a different learner than `r ref("LearnerRegrRpart", "lrn(\"regr.rpart\")")` without having to worry about implementation details:
 ```{r 05-pipelines-in-depth-002, output = FALSE}
 set.seed(1)
@@ -47,7 +47,7 @@ A term such as "directed acyclic multigraph" would be more accurate, but we will
 
 Some examples of operations that can be performed with `r mlr3pipelines` are:
 
-* Data manipulation and preprocessing operations, e.g. PCA, feature filtering, missing value imputation.
+* Data manipulation and preprocessing operations, e.g. principal component analysis (PCA), feature filtering, missing value imputation.
 * Task subsampling for speed or for handling of imbalanced classes.
 * Ensemble methods and aggregation of predictions.
 * Simultaneous model selection and hyperparameter tuning of both learners and preprocessing operators, by using `r mlr3tuning`. This is sometimes facetiously referred to as "CASH", standing for "Combined Algorithm Selection and Hyperparameter optimization" [@Thornton2013].
@@ -75,7 +75,7 @@ A very simple sequential Graph that does various preprocessing operations before
 knitr::include_graphics("Figures/state_graphic.svg")
 ```
 
-When evaluating the performance of an ML process consisting e.g. of preprocessing, followed by model fitting, it is strongly advised to always put the entire preprocessing operation *inside* the resampling loop, as is done here -- `r mlr3pipelines` encourages this more accurate approach.
+When evaluating the performance of a machine learning process consisting e.g. of preprocessing, followed by model fitting, it is strongly advised to always put the entire preprocessing operation *inside* the resampling loop, as is done here -- `r mlr3pipelines` encourages this more accurate approach.
 Making a PCA on the entirety of a dataset, followed by resampling a learner on it, would effectively leak information from the training set to the test set, leading to biased results.
 
 ## `r mlr3pipelines` by Example {#sec-pipelines-intro}
@@ -246,7 +246,7 @@ The `r mlr3pipelines` package contains a vignette on how to do this, which can b
 
 ### Basics: Building a `Graph`
 
-PipeOps are used to represent individual computational steps in ML pipelines.
+PipeOps are used to represent individual computational steps in machine learning pipelines.
 These pipelines themselves are defined by `r ref("Graph")` objects.
 A Graph is a collection of PipeOps with "edges" that guide the flow of data.
 

--- a/book/solutions.qmd
+++ b/book/solutions.qmd
@@ -98,7 +98,7 @@ rr$aggregate(msr("regr.mse"))
 ```
 
 
-2. Use the `spam` task and 5-fold cross-validation to benchmark Random Forest (`classif.ranger`), Logistic Regression (`classif.log_reg`), and XGBoost (`classif.xgboost`) with regards to AUC.
+2. Use the `spam` task and 5-fold CV to benchmark Random Forest (`classif.ranger`), Logistic Regression (`classif.log_reg`), and XGBoost (`classif.xgboost`) with regards to AUC.
 Which learner appears to do best? How confident are you in your conclusion?
 How would you improve upon this?
 
@@ -121,7 +121,7 @@ This is only a small example for a benchmark workflow, but without tuning (see @
 
 3. A colleague claims to have achieved a 93.1% classification accuracy using the `classif.rpart` learner on the `penguins_simple` task.
 You want to reproduce their results and ask them about their resampling strategy.
-They said they used a custom 3-fold cross-validation with folds assigned as `factor(task$row_ids %% 3)`.
+They said they used a custom 3-fold CV with folds assigned as `factor(task$row_ids %% 3)`.
 See if you can reproduce their results.
 
 ```{r solutions-008}
@@ -144,7 +144,7 @@ rr$aggregate(msr("classif.acc"))
 
 1. Tune the `mtry`, `sample.fraction`, ` num.trees` hyperparameters of a random forest model (`regr.ranger`) on the `mtcars` task.
 Use a simple random search with 50 evaluations and select a suitable batch size.
-Evaluate with a 3-fold cross-validation and the root mean squared error.
+Evaluate with a 3-fold CV and the root mean squared error.
 
 ```{r solutions-009}
 set.seed(4)
@@ -168,7 +168,7 @@ tuner$optimize(instance)
 ```
 
 2. Evaluate the performance of the model created in Question 1 with nested resampling.
-Use a holdout validation for the inner resampling and a 3-fold cross-validation for the outer resampling.
+Use a holdout validation for the inner resampling and a 3-fold CV for the outer resampling.
 Print the unbiased performance estimate of the model.
 
 ```{r solutions-010}
@@ -1173,7 +1173,7 @@ l2 = po("learner_cv", lrn("classif.rpart")) %>>%
   po("EOd")
 ```
 
-And run the benchmark again. Note, that we use 3-fold cross-validation this time for comparison.
+And run the benchmark again. Note, that we use 3-fold CV this time for comparison.
 
 ```{r}
 lrns = list(l, l1, l2)

--- a/book/special.qmd
+++ b/book/special.qmd
@@ -387,7 +387,7 @@ For more details about prediction types and compositions we recommend @Kalbfleis
 Finally, we will put all the above into practice in a small benchmark experiment.
 We first load the `r ref("grace")` dataset and subset to the first 500 rows.
 We then select the RCLL, D-Calibration, and C-index to evaluate predictions, setup the same pipeline we used in the previous experiment, and load a Cox PH and Kaplan-Meier estimator.
-We run our experiment with 3-fold cross-validation and aggregate the results.
+We run our experiment with 3-fold CV and aggregate the results.
 
 ```{r special-022, warning=FALSE}
 library(mlr3verse)

--- a/book/special.qmd
+++ b/book/special.qmd
@@ -228,7 +228,7 @@ The likely reason for this is due to the presence of censoring.
 We rarely observe the true survival time for many observations and therefore it is unlikely any survival model can confidently make predictions for survival times.
 This is illustrated in the code below.
 
-In the example below we train and predict from a survival support vector machine (`lrn("surv.svm")`), note we use `type = "regression"` to select the algorithm that optimizes survival time predictions and `gamma.mu = 1e-3` is selected arbitrarily as this is a required parameter (this parameter should usually be tuned).
+In the example below we train and predict from a survival SVM (`lrn("surv.svm")`), note we use `type = "regression"` to select the algorithm that optimizes survival time predictions and `gamma.mu = 1e-3` is selected arbitrarily as this is a required parameter (this parameter should usually be tuned).
 We then compare the predictions from the model to the true data.
 
 ```{r special-016}

--- a/book/special.qmd
+++ b/book/special.qmd
@@ -666,7 +666,7 @@ If we had only relied on the silhouette score, then the details of how exactly t
 
 #### PCA and Silhouette Plots
 
-The two most important plots implemented in `r mlr3viz` to support evaluation of cluster learners are `r index("principal components analysis")` (PCA) and silhouette plots.
+The two most important plots implemented in `r mlr3viz` to support evaluation of cluster learners are PCA and silhouette plots.
 
 PCA is a commonly used dimension reduction method in ML to reduce the number of variables in a dataset or to visualize the most important 'components', which are linear transformations of the dataset features.
 Components are considered more important if they have higher variance (and therefore more predictive power).
@@ -720,7 +720,7 @@ Spatial analysis can be a subset of any other machine learning task (e.g., regre
 Spatial analysis is its own task as spatial data must be handled carefully due to the complexity of 'autocorrelation'.
 Where `r index("correlation")` is defined as a statistical association *between two* variables, `r index("autocorrelation", aside = TRUE)` is a statistical association *within one* variable.
 In machine learning terms, in a dataset with features and observations, correlation occurs when two or more features are statistically associated in some way, whereas autocorrelation occurs when two or more observations are statistically associated across one feature.
-Autocorrelation therefore violates one of the fundamental assumptions of ML that all observations in a dataset are independent, which results in lower confidence about the quality of a trained ML model and the resulting performance estimates [@hastie2001].
+Autocorrelation therefore violates one of the fundamental assumptions of ML that all observations in a dataset are independent, which results in lower confidence about the quality of a trained machine learning model and the resulting performance estimates [@hastie2001].
 
 Autocorrelation is present in spatial data as there is implicit information encoded in coordinates, such as whether two observations (e.g., cities, countries, continents) are close together or far apart.
 For example, say we are predicting the number of cases of a disease two months after outbreak in Germany.

--- a/book/technical.qmd
+++ b/book/technical.qmd
@@ -825,7 +825,7 @@ DBI::dbDisconnect(con)
 
 ### Parquet Files with DataBackendDuckDB
 
-`r index("DuckDB")` databases provide a modern alternative to SQLite, tailored to the needs of machine learning.
+`r index("DuckDB")` databases provide a modern alternative to SQLite, tailored to the needs of ML.
 Parquet is a popular column-oriented data storage format supporting efficient compression, making it far superior to other popular data exchange formats such as CSV.
 
 Converting a `data.frame` to DuckDB is possible by passing the `data.frame` to convert and the `path` to store the data to `r ref("mlr3db::as_duckdb_backend()")`.

--- a/book/technical.qmd
+++ b/book/technical.qmd
@@ -181,7 +181,7 @@ By definition, resampling is performed by aggregating over independent repetitio
 
 `r mlr3` makes use of `r ref_pkg("future")` to enable parallelization over resampling iterations using the parallel backend configured by the user via the `r ref("future::plan()")` function.
 
-By example, we will look at parallelizing three-fold cross-validation for a decision tree on the spam task, this is also illustrated in @fig-parallel-overview.
+By example, we will look at parallelizing three-fold CV for a decision tree on the spam task, this is also illustrated in @fig-parallel-overview.
 We use the `r ref("future::multisession")` plan (which internally uses socket clusters from the `parallel` package) that should work on all operating systems.
 
 ```{r technical-005}
@@ -217,7 +217,7 @@ Tuning the chunk size can help in some rare cases to mitigate the parallelizatio
 
 ```{mermaid}
 %%| label: fig-parallel-overview
-%%| fig-cap: Parallelization of a resampling using 3-fold cross-validation. The main process calls the `resample()` function, which starts the parallelization process and the computational task is split into 3 parts for 3-fold CV. The folds are passed to 3 workers, each fitting a model on the respective subset of the task and predicting on the left-out observations. The predictions (and trained models) are communicated back to main process which combines them into a `ResampleResult`.
+%%| fig-cap: Parallelization of a resampling using 3-fold CV. The main process calls the `resample()` function, which starts the parallelization process and the computational task is split into 3 parts for 3-fold CV. The folds are passed to 3 workers, each fitting a model on the respective subset of the task and predicting on the left-out observations. The predictions (and trained models) are communicated back to main process which combines them into a `ResampleResult`.
 graph LR
     M[Main]
     S{"resample()"}
@@ -330,7 +330,7 @@ Let's assume we have four cores available and each job takes 4s, and consider ea
 
 If we parallelize the outer five-fold CV (@fig-parallel-outer), all four cores would be utilized first with the computation of the first 4 resampling iterations and the computation of the fifth iteration has to wait.
 Assume that each fit during the inner resampling takes 4 seconds to compute and that there is no other significant overhead.
-Then, each of the four workers starts with the computation of an inner 2-fold cross-validation.
+Then, each of the four workers starts with the computation of an inner 2-fold CV.
 As there are more jobs than workers, the remaining fifth iteration of the outer resampling is queued on CPU1 **after** the first 4 iterations are finished after 8 secs.
 During the computation of the 5th outer resampling iteration, only CPU1 is utilized, the other 3 CPUs are idling.
 In fact, even if we had setup the parallelization with `"multisession"` in both inner and outer CV, it would have the same result, the outer loop is parallelized while all subsequent loops default to sequential execution.
@@ -339,7 +339,7 @@ In contrast, if we parallelize the inner two-fold CV (@fig-parallel-inner) then 
 
 ```{mermaid}
 %%| label: fig-parallel-outer
-%%| fig-cap: CPU utilization for 4 CPUs while parallelizing the outer 5-fold cross-validation with a sequential 2-fold cross-validation inside. Jobs are labeled as [iteration outer]-[iteration inner].
+%%| fig-cap: CPU utilization for 4 CPUs while parallelizing the outer 5-fold CV with a sequential 2-fold CV inside. Jobs are labeled as [iteration outer]-[iteration inner].
 gantt
     title CPU Utilization
     dateFormat  s
@@ -368,7 +368,7 @@ gantt
 
 ```{mermaid}
 %%| label: fig-parallel-inner
-%%| fig-cap: CPU utilization for 4 CPUs while parallelizing the inner 2-fold cross-validation with a sequential 5-fold cross-validation outside. Jobs are labeled as [iteration outer]-[iteration inner].
+%%| fig-cap: CPU utilization for 4 CPUs while parallelizing the inner 2-fold CV with a sequential 5-fold CV outside. Jobs are labeled as [iteration outer]-[iteration inner].
 gantt
     title CPU Utilization
     dateFormat  s

--- a/book/technical.qmd
+++ b/book/technical.qmd
@@ -5,8 +5,8 @@
 `r chapter = "Advanced Technical Aspects of mlr3"`
 `r authors(chapter)`
 
-In the previous chapters, we demonstrated how to turn ML concepts and ML methods into code.
-So far, we have covered ML concepts without going into a lot of technical detail, which can be important for more advanced uses of mlr3.
+In the previous chapters, we demonstrated how to turn machine learning concepts and machine learning methods into code.
+So far, we have covered machine learning concepts without going into a lot of technical detail, which can be important for more advanced uses of mlr3.
 This includes the following topics:
 
 * Parallelization with the `r ref_pkg("future")` framework (@sec-parallelization),
@@ -24,7 +24,7 @@ The term `r index("parallelization")` refers to running multiple algorithms in p
 Not all algorithms can be parallelized, but when they can, parallelization allows significant savings in computation time.
 
 In general, there are many possibilities to parallelize, depending on the hardware to run the computations: If you only have a single CPU with multiple cores, then *threads* or *processes* are ways to utilize all cores on a local machine.
-If you have multiple machines on the other hand, they can communicate and exchange information via protocols such as *network sockets* or the *Message Passing Interface* (MPI).
+If you have multiple machines on the other hand, they can communicate and exchange information via protocols such as *network sockets* or the *Message Passing Interface*.
 Larger computational sites rely on a scheduler to orchestrate the computation for multiple users and offer a shared network file system all machines can access.
 Interacting with scheduling systems on compute clusters is covered in @sec-hpc-exec using the R package `r ref_pkg("batchtools")`.
 
@@ -450,7 +450,7 @@ learner$predict(task)
 
 ## Error Handling {#sec-error-handling}
 
-In large ML experiments, it is not uncommon that a model fit or prediction fails with an error.
+In large machine learning experiments, it is not uncommon that a model fit or prediction fails with an error.
 This is because the algorithms have to process arbitrary data, and not all eventualities can always be handled.
 While we try to identify obvious problems before execution, such as when missing values occur, but a learner cannot handle them, other problems are far more complex to detect.
 Examples include numerical problems that may cause issues in training (e.g., due to lack of convergence), or new levels of categorical variables appearing in the predict step.


### PR DESCRIPTION
# Rules

* Introduce abbreviations in the corresponding chapters or sections e.g. HPO in the optimization chapter and not in intro chapter.
* Introduce abbreviations when the term is explained.
* Keep abbreviations (Learner, Measures and Algorithms) that are only repeated in the code e.g. ACC only in `msr("classif.acc")`
* Do not use terms like ML algorithms instead machine learning algorithms

# Used abbreviations

**basis.qmd**
ML
MSE
MAE

**performance.qmd**
CV
LOO-CV
MSE
TPR
TNR
FPR
PPV
NPV
ACC
AUC
PRC

**optimization.qmd**
HPO
SVM
CMA-ES

**advanced_tuning.qmd**
BO
MBO
EGO

**sequential_popelines.qmd**
DAG
PCA

**nono_sequential_popelines.qmd**
KKN

**preprocessing.qmd**
GLM
GAM
OOR

**large_benchmarking.qmd**
HPC

**interpretation.qmd**
IML
GBM
PFI
PD
ICE
MOC
EMA
SHAP

**special.qmd**
WSS


# Removed abbreviations

OOP
NLP - Natural language processing
CV - Computer Vision
MPI
PC