### PR TITLE
fix chapter1 html output

### DIFF
--- a/book/chapters/chapter1/introduction_and_overview.qmd
+++ b/book/chapters/chapter1/introduction_and_overview.qmd
@@ -308,7 +308,7 @@ Plot types are documented in the respective manual page that can be accessed thr
 
 {{< include ../../common/_optional.qmd >}}
 
-Learning from over a decade of design and adaptation from \texttt{mlr} to \texttt{mlr3}, we now follow these design principles in the \texttt{mlr3} ecosystem:
+Learning from over a decade of design and adaptation from `r ref_pkg("mlr")` to `r mlr3`, we now follow these design principles in the `r mlr3` ecosystem:
 
 *   **Object-oriented programming**.
 We embrace `r ref_pkg("R6")` for a clean, object-oriented design, object state changes, and reference semantics.


### PR DESCRIPTION
`\texttt{mlr}` and `\texttt{mlr3}` are not displayed in HTML output.

![image](https://github.com/Shitao5/mlr3book/assets/68451957/0bbe1d1e-dbb7-4659-bbaf-1d54ec2b29a7)

![image](https://github.com/Shitao5/mlr3book/assets/68451957/e47523e3-3f1c-4acc-a6b9-5007f9c33692)
