### PR TITLE
Fix citation on first page

### DIFF
--- a/book/index.qmd
+++ b/book/index.qmd
@@ -62,8 +62,8 @@ Bischl, B., Sonabend, R., Kotthoff, L., & Lang, M. (Eds.). (2024).
 "{{< meta book.title >}}". CRC Press. https://mlr3book.mlr-org.com
 
 @book{Bischl2024
-    title = {{< meta book.title >}}
-    editor = {Bernd Bischl, Raphael Sonabend, Lars Kotthoff, Michel Lang},
+    title = {{{< meta book.title >}}},
+    editor = {Bernd Bischl and Raphael Sonabend and Lars Kotthoff and Michel Lang},
     url = {https://mlr3book.mlr-org.com},
     year = {2024},
     isbn = {9781032507545},


### PR DESCRIPTION
The citation on the first pages was not copy-into-my-bib-file-able, as


- The title needed to be in `{ }`
- Missing `,` after the title
- Editor names needed to be separated by `and`