### PR TITLE
fix: use old renv version and upgrade mlr3misc version

### DIFF
--- a/.github/workflows/book-weekly.yml
+++ b/.github/workflows/book-weekly.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Restore renv environment
         run: |
           cd book
-          R -q -e 'options(Ncpus = 2); install.packages("renv", repos = "cloud.r-project.org"); renv::restore()'
+          R -q -e 'options(Ncpus = 2); install.packages("remotes", repos = "cloud.r-project.org"); remotes::install_version("renv", "0.17.0"); renv::restore()'
 
       - name: Update renv environment
         run: |

--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Restore renv environment
         run: |
           cd book
-          R -q -e 'options(Ncpus = 2); install.packages("renv", repos = "cloud.r-project.org"); renv::restore()'
+          R -q -e 'options(Ncpus = 2); install.packages("remotes", repos = "cloud.r-project.org"); remotes::install_version("renv", "0.17.0"); renv::restore()'
 
       - name: Restore OpenML cache
         uses: actions/cache/restore@v3

--- a/book/renv.lock
+++ b/book/renv.lock
@@ -3470,7 +3470,6 @@
       "RemoteRef": "main",
       "RemoteSha": "d50c4bc45f2b33f1e594b611048f008bcd0508e4",
       "Remotes": "alan-turing-institute/distr6, binderh/CoxBoost, mlr-org/mlr3proba,\n    RaphaelS1/survivalmodels, xoopR/param6, xoopR/set6",
-      "Remotes": "alan-turing-institute/distr6, binderh/CoxBoost, mlr-org/mlr3proba,\n    RaphaelS1/survivalmodels, xoopR/param6, xoopR/set6",
       "Requirements": [
         "R",
         "R6",
@@ -3481,7 +3480,7 @@
         "mlr3misc",
         "paradox"
       ],
-      "Hash": "705852b917ca86e448bb58258da1f973"
+      "Hash": "9bc0d509207ec242a642de05d40f1f01"
     },
     "mlr3fairness": {
       "Package": "mlr3fairness",

--- a/book/renv.lock
+++ b/book/renv.lock
@@ -3470,6 +3470,7 @@
       "RemoteRef": "main",
       "RemoteSha": "d50c4bc45f2b33f1e594b611048f008bcd0508e4",
       "Remotes": "alan-turing-institute/distr6, binderh/CoxBoost, mlr-org/mlr3proba,\n    RaphaelS1/survivalmodels, xoopR/param6, xoopR/set6",
+      "Remotes": "alan-turing-institute/distr6, binderh/CoxBoost, mlr-org/mlr3proba,\n    RaphaelS1/survivalmodels, xoopR/param6, xoopR/set6",
       "Requirements": [
         "R",
         "R6",
@@ -3480,7 +3481,7 @@
         "mlr3misc",
         "paradox"
       ],
-      "Hash": "9bc0d509207ec242a642de05d40f1f01"
+      "Hash": "705852b917ca86e448bb58258da1f973"
     },
     "mlr3fairness": {
       "Package": "mlr3fairness",
@@ -3617,7 +3618,7 @@
     },
     "mlr3misc": {
       "Package": "mlr3misc",
-      "Version": "0.12.0",
+      "Version": "0.13.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3629,7 +3630,7 @@
         "digest",
         "methods"
       ],
-      "Hash": "6b7b91bcab360eda9a07ce05452a3e74"
+      "Hash": "d6e11a7820fe331d8dfbd66762fd19c3"
     },
     "mlr3oml": {
       "Package": "mlr3oml",


### PR DESCRIPTION
The "large-scale benchmarking" chapter always threw because of a change in renv that started to install packages with --with-keep.source this had two problems:
1. methods of R6 intances had a srcref object containing a promise with a large environment
2. function parameters (as in the robustify pipeline) were also quite large because from there one can also reach enviroments where a lot of srcrefs are kept

While this is inherently an issue that needs to be addressed in renv -- i.e. there should be an option to not keep the source -- we here fix it temporarily by relying on an older renv version and bumping the mlr3misc version where the problem is solved

https://github.com/rstudio/renv/issues/1713
https://github.com/mlr-org/mlr3misc/issues/88