### PR TITLE
Update non-sequential_pipelines_and_tuning.qmd

### DIFF
--- a/book/chapters/chapter8/non-sequential_pipelines_and_tuning.qmd
+++ b/book/chapters/chapter8/non-sequential_pipelines_and_tuning.qmd
@@ -797,6 +797,7 @@ po_filter = po("filter", filter = flt("information_gain"),
 
 graph = as_learner(po_filter %>>% po("learner", lrn("classif.rpart")))
 
+set.seed(1234)
 instance = tune(tnr("random_search"), task_pen, graph,
   rsmp("cv", folds = 3), term_evals = 10)
 instance$result


### PR DESCRIPTION
The addition of a random seed `set.seed(1234)` makes the results of the random search `tnr("random_search")` reproducible and aligns with the current description in the book.

![image](https://github.com/mlr-org/mlr3book/assets/68451957/9cb7d0dd-c75b-417c-938b-019cbccea67f)

![image](https://github.com/mlr-org/mlr3book/assets/68451957/418412d9-0890-4122-a9a6-feeff2465ca8)