### PR TITLE
Remove rgdal from renv.lock (archived on CRAN, unused in book)

### DIFF
--- a/book/renv.lock
+++ b/book/renv.lock
@@ -4913,22 +4913,6 @@
       ],
       "Hash": "ae34cd56890607370665bee5bd17812f"
     },
-    "rgdal": {
-      "Package": "rgdal",
-      "Version": "1.6-6",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "grDevices",
-        "graphics",
-        "methods",
-        "sp",
-        "stats",
-        "utils"
-      ],
-      "Hash": "05c7c91191407d54da92816fb849ab29"
-    },
     "rgenoud": {
       "Package": "rgenoud",
       "Version": "5.9-0.3",


### PR DESCRIPTION
This broke CI here https://github.com/mlr-org/mlr3book/actions/runs/6529774817/job/17962351599?pr=733

Waiting to see if removing rgdal just fixes it.