### PR TITLE
Add redirect to make old /solutions.html link work again

### DIFF
--- a/book/chapters/appendices/solutions.qmd
+++ b/book/chapters/appendices/solutions.qmd
@@ -1,6 +1,8 @@
 ---
 params:
     rebuild_cache: true
+aliases:
+  - "/solutions.html"
 ---
 
 # Solutions to exercises {#sec-solutions}


### PR DESCRIPTION
Addresses #747 by adding a [quarto redirect](https://quarto.org/docs/websites/website-navigation.html#redirects) from `/solutions.html` to the current link.

Note the leading `/` is necessary to have the redirect "start" at the root of the URL, i.e. `mlr3book.mlr-org.com/`

This became necessary as all chapters were restructured into a different folder hierarchy, so we will likely need to add a bunch of aliases for old links to chapters.