### PR TITLE
Actually fix index bibtex title display

### DIFF
--- a/book/index.qmd
+++ b/book/index.qmd
@@ -280,7 +280,7 @@ Bischl, B., Sonabend, R., Kotthoff, L., & Lang, M. (Eds.). (2024).
 "{{< meta book.title >}}". CRC Press. https://mlr3book.mlr-org.com
 
 @book{Bischl2024
-    title = {Applied Machine Learning Using mlr3 in R}
+    title = {Applied Machine Learning Using mlr3 in R},
     editor = {Bernd Bischl and Raphael Sonabend and Lars Kotthoff and Michel Lang},
     url = {https://mlr3book.mlr-org.com},
     year = {2024},

--- a/book/index.qmd
+++ b/book/index.qmd
@@ -281,7 +281,7 @@ Bischl, B., Sonabend, R., Kotthoff, L., & Lang, M. (Eds.). (2024).
 
 @book{Bischl2024
     title = {Applied Machine Learning Using mlr3 in R}
-    editor = {Bernd Bischl, Raphael Sonabend, Lars Kotthoff, Michel Lang},
+    editor = {Bernd Bischl and Raphael Sonabend and Lars Kotthoff and Michel Lang},
     url = {https://mlr3book.mlr-org.com},
     year = {2024},
     isbn = {9781032507545},

--- a/book/index.qmd
+++ b/book/index.qmd
@@ -66,7 +66,7 @@ Bischl, B., Sonabend, R., Kotthoff, L., & Lang, M. (Eds.). (2024).
 "{{< meta book.title >}}". CRC Press. https://mlr3book.mlr-org.com
 
 @book{Bischl2024
-    title = {Applied Machine Learning Using mlr3 in R},
+    title = {Applied Machine Learning Using {m}lr3 in {R}},
     editor = {Bernd Bischl and Raphael Sonabend and Lars Kotthoff and Michel Lang},
     url = {https://mlr3book.mlr-org.com},
     year = {2024},
@@ -280,7 +280,7 @@ Bischl, B., Sonabend, R., Kotthoff, L., & Lang, M. (Eds.). (2024).
 "{{< meta book.title >}}". CRC Press. https://mlr3book.mlr-org.com
 
 @book{Bischl2024
-    title = {Applied Machine Learning Using mlr3 in R},
+    title = {Applied Machine Learning Using {m}lr3 in {R}},
     editor = {Bernd Bischl and Raphael Sonabend and Lars Kotthoff and Michel Lang},
     url = {https://mlr3book.mlr-org.com},
     year = {2024},

--- a/book/index.qmd
+++ b/book/index.qmd
@@ -66,7 +66,7 @@ Bischl, B., Sonabend, R., Kotthoff, L., & Lang, M. (Eds.). (2024).
 "{{< meta book.title >}}". CRC Press. https://mlr3book.mlr-org.com
 
 @book{Bischl2024
-    title = {{{< meta book.title >}}},
+    title = {Applied Machine Learning Using mlr3 in R},
     editor = {Bernd Bischl and Raphael Sonabend and Lars Kotthoff and Michel Lang},
     url = {https://mlr3book.mlr-org.com},
     year = {2024},
@@ -280,7 +280,7 @@ Bischl, B., Sonabend, R., Kotthoff, L., & Lang, M. (Eds.). (2024).
 "{{< meta book.title >}}". CRC Press. https://mlr3book.mlr-org.com
 
 @book{Bischl2024
-    title = {{< meta book.title >}}
+    title = {Applied Machine Learning Using mlr3 in R}
     editor = {Bernd Bischl, Raphael Sonabend, Lars Kotthoff, Michel Lang},
     url = {https://mlr3book.mlr-org.com},
     year = {2024},


### PR DESCRIPTION
The first page displays the bibtex citation which should look like this:

```
@book{Bischl2024
    title = {Applied Machine Learning Using mlr3 in R},
    editor = {Bernd Bischl and Raphael Sonabend and Lars Kotthoff and Michel Lang},
    url = {https://mlr3book.mlr-org.com},
    year = {2024},
    isbn = {9781032507545},
    publisher = {CRC Press}
}
```

but due to an oversight an earlier version used

```
title = {{< meta book.title >}},
```

which was wrongly rendered without the `{ }` braces around the title field, since `{{ }}` are quarto's shortcode delimiters.

I thought I had fixed this in an earlier PR, but I failed to notice that `{{{ }}}` is quarto's way of [escaping shortcodes](https://quarto.org/docs/extensions/shortcodes.html#escaping).
I also failed to noticed that further down, the same content is repeated for the PDF output, where the original formatting error persisted.

I have now opted to not try to use quarto's metadata shortcodes and just plainly inserted the full title of the book where needed, as I do not think it's worth it to spend more time trying to outsmart any shortcode escaping behavior given that the title of the book is not going to change anytime soon 😅 

- [x] Actually triple double check both HTML and PDF version look correct now with these changes