### PR TITLE
Add quarto aliases to each chapter

### DIFF
--- a/book/chapters/appendices/overview-tables.qmd
+++ b/book/chapters/appendices/overview-tables.qmd
@@ -1,3 +1,8 @@
+---
+aliases:
+  - "/overview_tables.html"
+---
+
 # Overview Tables {#sec-appendix-overview-tables}
 
 ::: {.content-visible when-format="html"}

--- a/book/chapters/appendices/tasks.qmd
+++ b/book/chapters/appendices/tasks.qmd
@@ -1,3 +1,7 @@
+---
+aliases:
+  - "/tasks.html"
+---
 # Tasks {#sec-appendix-tasks}
 
 ::: {.content-visible when-format="html"}

--- a/book/chapters/chapter1/introduction_and_overview.qmd
+++ b/book/chapters/chapter1/introduction_and_overview.qmd
@@ -1,3 +1,8 @@
+---
+aliases:
+  - "/introduction_and_overview.html"
+---
+
 # Introduction and Overview {#sec-introduction}
 
 {{< include ../../common/_setup.qmd >}}

--- a/book/chapters/chapter10/advanced_technical_aspects_of_mlr3.qmd
+++ b/book/chapters/chapter10/advanced_technical_aspects_of_mlr3.qmd
@@ -1,3 +1,8 @@
+---
+aliases:
+  - "/advanced_technical_aspects_of_mlr3.html"
+---
+
 # Advanced Technical Aspects of mlr3 {#sec-technical}
 
 {{< include ../../common/_setup.qmd >}}

--- a/book/chapters/chapter11/large-scale_benchmarking.qmd
+++ b/book/chapters/chapter11/large-scale_benchmarking.qmd
@@ -1,3 +1,8 @@
+---
+aliases:
+  - "/large-scale_benchmarking.html"
+---
+
 # Large-Scale Benchmarking {#sec-large-benchmarking}
 
 {{< include ../../common/_setup.qmd >}}

--- a/book/chapters/chapter12/model_interpretation.qmd
+++ b/book/chapters/chapter12/model_interpretation.qmd
@@ -1,3 +1,8 @@
+---
+aliases:
+  - "/model_interpretation.html"
+---
+
 # Model Interpretation {#sec-interpretation}
 
 {{< include ../../common/_setup.qmd >}}

--- a/book/chapters/chapter13/beyond_regression_and_classification.qmd
+++ b/book/chapters/chapter13/beyond_regression_and_classification.qmd
@@ -1,3 +1,8 @@
+---
+aliases:
+  - "/beyond_regression_and_classification.html"
+---
+
 # Beyond Regression and Classification {#sec-special}
 
 {{< include ../../common/_setup.qmd >}}

--- a/book/chapters/chapter14/algorithmic_fairness.qmd
+++ b/book/chapters/chapter14/algorithmic_fairness.qmd
@@ -1,3 +1,8 @@
+---
+aliases:
+  - "/algorithmic_fairness.html"
+---
+
 # Algorithmic Fairness {#sec-fairness}
 
 {{< include ../../common/_setup.qmd >}}

--- a/book/chapters/chapter2/data_and_basic_modeling.qmd
+++ b/book/chapters/chapter2/data_and_basic_modeling.qmd
@@ -1,3 +1,8 @@
+---
+aliases:
+  - "/data_and_basic_modeling.html"
+---
+
 # Data and Basic Modeling {#sec-basics}
 
 {{< include ../../common/_setup.qmd >}}

--- a/book/chapters/chapter3/evaluation_and_benchmarking.qmd
+++ b/book/chapters/chapter3/evaluation_and_benchmarking.qmd
@@ -1,3 +1,8 @@
+---
+aliases:
+  - "/evaluation_and_benchmarking.html"
+---
+
 # Evaluation and Benchmarking {#sec-performance}
 
 {{< include ../../common/_setup.qmd >}}

--- a/book/chapters/chapter4/hyperparameter_optimization.qmd
+++ b/book/chapters/chapter4/hyperparameter_optimization.qmd
@@ -1,3 +1,8 @@
+---
+aliases:
+  - "/hyperparameter_optimization.html"
+---
+
 # Hyperparameter Optimization {#sec-optimization}
 
 {{< include ../../common/_setup.qmd >}}

--- a/book/chapters/chapter5/advanced_tuning_methods_and_black_box_optimization.qmd
+++ b/book/chapters/chapter5/advanced_tuning_methods_and_black_box_optimization.qmd
@@ -1,3 +1,8 @@
+---
+aliases:
+  - "/advanced_tuning_methods_and_black_box_optimization.html"
+---
+
 # Advanced Tuning Methods and Black Box Optimization {#sec-optimization-advanced}
 
 {{< include ../../common/_setup.qmd >}}

--- a/book/chapters/chapter6/feature_selection.qmd
+++ b/book/chapters/chapter6/feature_selection.qmd
@@ -1,3 +1,8 @@
+---
+aliases:
+  - "/feature_selection.html"
+---
+
 # Feature Selection {#sec-feature-selection}
 
 {{< include ../../common/_setup.qmd >}}

--- a/book/chapters/chapter7/sequential_pipelines.qmd
+++ b/book/chapters/chapter7/sequential_pipelines.qmd
@@ -1,3 +1,8 @@
+---
+aliases:
+  - "/sequential_pipelines.html"
+---
+
 # Sequential Pipelines {#sec-pipelines}
 
 {{< include ../../common/_setup.qmd >}}

--- a/book/chapters/chapter8/non-sequential_pipelines_and_tuning.qmd
+++ b/book/chapters/chapter8/non-sequential_pipelines_and_tuning.qmd
@@ -1,3 +1,8 @@
+---
+aliases:
+  - "/non-sequential_pipelines_and_tuning.html"
+---
+
 # Non-sequential Pipelines and Tuning {#sec-pipelines-nonseq}
 
 {{< include ../../common/_setup.qmd >}}

--- a/book/chapters/chapter9/preprocessing.qmd
+++ b/book/chapters/chapter9/preprocessing.qmd
@@ -1,3 +1,8 @@
+---
+aliases:
+  - "/preprocessing.html"
+---
+
 # Preprocessing {#sec-preprocessing}
 
 {{< include ../../common/_setup.qmd >}}

--- a/book/chapters/references.qmd
+++ b/book/chapters/references.qmd
@@ -1,3 +1,9 @@
+---
+aliases:
+  - "/references.html"
+---
+
+
 # References
 
 ::: {#refs}


### PR DESCRIPTION
This adds additional chapter URL aliases to each chapter, like #748 did for `/solutions.html`.  
It only affects the HTML version, and does not change visible text.

This aims to ensure that

- The citation information at the end of each chapter shows a URL that actually works
- Old links to the book spread around e.g. stackoverflow or our own package documentation still works

To check that this does what it's supposed to:

- [x] Wait for netlify preview and manually check each chapter citation link
- Next step: Clone all mlr3 packages, `grep` for `mlr3book` and manually test all links maybe?
