### PR TITLE
Improve reproducibility and clarity in fairness chapter example

### DIFF
--- a/book/chapters/chapter14/algorithmic_fairness.qmd
+++ b/book/chapters/chapter14/algorithmic_fairness.qmd
@@ -24,6 +24,8 @@ As we work through this chapter we will use the `"adult_train"` and `"adult_test
 This is a binary classification task to predict if an individual earns more than $50,000 per year and is useful for demonstrating biases in data.
 
 ```{r algorithmic_fairness-001}
+library(mlr3)
+library(mlr3learners)
 library(mlr3fairness)
 tsk_adult_train = tsk("adult_train")
 tsk_adult_train
@@ -33,7 +35,7 @@ tsk_adult_train
 
 In the context of fairness, `r index('bias', aside = TRUE)` refers to disparities in how a model treats individuals or groups.
 In this chapter, we will concentrate on a subset of bias definitions, those concerning `r index('group fairness', aside = TRUE)`.
-For example, in the adult dataset, it can be seen that adults in the group 'Male' are significantly more likely to earn a salary greater than $50K per year when compared to the group 'Female'.
+For example, in the adult dataset, it can be seen that adults in the group 'Male' are significantly more likely to earn a salary greater than $50K per year when compared to the group 'Female'.Column roles in mlr3 define how variables are used during model training and evaluation.
 
 ```{r algorithmic_fairness-002}
 sex_salary = table(tsk_adult_train$data(cols = c("sex", "target")))


### PR DESCRIPTION
Explicitly load mlr3 and mlr3learners in the fairness chapter examples to improve reproducibility for readers running the code snippets.