### PR TITLE
Added cross-ref to feature/target trafos; minor prose fixes

### DIFF
--- a/book/chapters/chapter2/data_and_basic_modeling.qmd
+++ b/book/chapters/chapter2/data_and_basic_modeling.qmd
@@ -678,7 +678,7 @@ Note that we passed the task and learner as the measure has the `requires_task` 
 
 We have now seen how to train a model, make predictions and score them.
 What we have not yet attempted is to ascertain if our predictions are any 'good'.
-So before look at how the building blocks of `mlr3` extend to classification, we will take a brief pause to put together everything above in a short experiment to assess the quality of our predictions.
+So before looking at how the building blocks of `mlr3` extend to classification, we will take a brief pause to put together everything above in a short experiment to assess the quality of our predictions.
 We will do this by comparing the performance of a featureless regression learner to a decision tree with changed hyperparameters.
 
 ```{r data_and_basic_modeling-053}
@@ -1029,7 +1029,7 @@ In @sec-cost-sens we will look at `r index('cost-sensitive classification', "cos
 Now that we have covered regression and classification, we will briefly return to tasks and in particular to `r index('column roles')`, which are used to customize tasks further.
 Column roles are used by `Task` objects to define important metadata that can be used by learners and other objects to interact with the task.
 True to their name, they assign particular roles to columns in the data, we have already seen some of these in action with targets and features.
-There are seven column roles:
+There are eight column roles:
 
 1. `"feature"`: Features used for prediction.
 2. `"target"`: Target variable to predict.
@@ -1040,7 +1040,8 @@ There are seven column roles:
 7. `"weights_learner"`: Weights used during training by the learner. Only one numeric column may have this role.
 8. `"weights_measure"`: Weights used during scoring by the measure. Only one numeric column may have this role.
 
-We have already seen how features and targets work in @sec-tasks, which are the only column roles that each task must have.
+We have already seen how features and targets work in @sec-tasks, which are the only column roles that each task must have. 
+It may be useful to transform either of these types of columns. Feature transformations using `mlr3pipelines` are discussed throughout chapters 7-9, and in particular in @sec-prepro-scale, which also describes target transformations using `ppl("targettrafo")`.
 In @sec-strat-group we will have a look at the `stratum` and `group` column roles.
 So, for now, we will only look at `order`, and `weight`.
 We will not go into detail about `name`, which is primarily used in plotting and will almost always be the `rownames()` of the underlying data.

--- a/book/chapters/chapter2/data_and_basic_modeling.qmd
+++ b/book/chapters/chapter2/data_and_basic_modeling.qmd
@@ -1041,7 +1041,7 @@ There are eight column roles:
 8. `"weights_measure"`: Weights used during scoring by the measure. Only one numeric column may have this role.
 
 We have already seen how features and targets work in @sec-tasks, which are the only column roles that each task must have. 
-It may be useful to transform either of these types of columns. Feature transformations using `mlr3pipelines` are discussed throughout chapters 7-9, and in particular in @sec-prepro-scale, which also describes target transformations using `ppl("targettrafo")`.
+It may be useful to transform either of these types of columns. Feature transformations using `mlr3pipelines` are discussed throughout Chapters 7-9, and in particular in @sec-prepro-scale, which also describes target transformations using `ppl("targettrafo")`.
 In @sec-strat-group we will have a look at the `stratum` and `group` column roles.
 So, for now, we will only look at `order`, and `weight`.
 We will not go into detail about `name`, which is primarily used in plotting and will almost always be the `rownames()` of the underlying data.

--- a/book/chapters/chapter2/data_and_basic_modeling.qmd
+++ b/book/chapters/chapter2/data_and_basic_modeling.qmd
@@ -1041,7 +1041,7 @@ There are eight column roles:
 8. `"weights_measure"`: Weights used during scoring by the measure. Only one numeric column may have this role.
 
 We have already seen how features and targets work in @sec-tasks, which are the only column roles that each task must have. 
-It may be useful to transform either of these types of columns. Feature transformations using `mlr3pipelines` are discussed throughout Chapters 7-9, and in particular in @sec-prepro-scale, which also describes target transformations using `ppl("targettrafo")`.
+It may be useful to transform either of these types of columns. Feature transformations using `mlr3pipelines` are discussed in @sec-pipelines, @sec-pipelines-nonseq, and @sec-preprocessing: in particular, in @sec-prepro-scale, which also describes target transformations using `ppl("targettrafo")`.
 In @sec-strat-group we will have a look at the `stratum` and `group` column roles.
 So, for now, we will only look at `order`, and `weight`.
 We will not go into detail about `name`, which is primarily used in plotting and will almost always be the `rownames()` of the underlying data.


### PR DESCRIPTION
Resolves #910 by mentioning feature and target transformations in Chapter 2, as requested by @tdhock.

For Chapter 3, I didn't see a good place to mention them. We could consider adding a new subsection, if someone else believes it's important.

Other than that, just minor prose fixes.